### PR TITLE
Update content type of PDF's

### DIFF
--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -378,7 +378,7 @@ def createPdf(htmlreport, outfile=None, css=None):
     return open(outfile, 'r').read();
 
 def attachPdf(mimemultipart, pdfreport, filename=None):
-    part = MIMEBase('application', "application/pdf")
+    part = MIMEBase('application', "pdf")
     part.add_header('Content-Disposition',
                     'attachment; filename="%s.pdf"' % (filename or tmpID()))
     part.set_payload(pdfreport)


### PR DESCRIPTION
Without this fix the content-type gets set to "application/application/pdf" which will cause problems on some mail servers.