### PR TITLE
Issue/lims 1536 Add buttons for reference widgets dynamically

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.7 (unreleased)
 -----
 
+LIMS-1536: Add button [Add], to alow quickly addings in referencewidget
 LIMS-1587: Custom sample labels
 LIMS-1517: Storage field tag untranslated?
 LIMS-1518: Storage Location table

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -397,6 +397,14 @@ function AnalysisRequestAddView() {
 			$(e).attr("name", "ar."+column+"."+eid+"-listing");
 			$(e).attr("fieldName", "ar."+column+"."+eid);
 		}
+		//Adding a unique identification to the widget's add button.
+		elements = $("a.add_button_overlay");
+		for (i = elements.length - 1; i >= 0; i--) {
+			e = elements[i];
+			column = $($(e).parents("td")).attr("column");
+			var line = $(e).parents("div").attr("data-fieldname");
+			$(e).attr("id", "ar_"+column+"_"+ e.id);
+		}
 	}
 
 	// The columnar referencewidgets that we reconfigure use this as their

--- a/bika/lims/browser/js/bika.lims.loader.js
+++ b/bika/lims/browser/js/bika.lims.loader.js
@@ -159,6 +159,8 @@ window.bika.lims.controllers =  {
 
 
 
+var _bika_lims_loaded_js = new Array();
+
 /**
  * Initializes only the js controllers needed for the current view.
  * Initializes the JS objects from the controllers dictionary for which
@@ -166,19 +168,33 @@ window.bika.lims.controllers =  {
  * loaded in the same order as defined in the controllers dict.
  */
 window.bika.lims.initview = function() {
-    var loaded = new Array();
+    return window.bika.lims.loadControllers(false, []);
+};
+/**
+ * all is a bool variable used to load all the controllers.
+ * controllerKeys is an array which contains specific controllers' keys which aren't
+ * in the current view, but you want to be loaded anyway. To deal with overlay
+ * widgets, for example.
+ */
+window.bika.lims.loadControllers = function(all, controllerKeys) {
     var controllers = window.bika.lims.controllers;
+    var prev = _bika_lims_loaded_js.length;
+    if (controllerKeys.length){
+        controllerKeys = controllerKeys.split(",")
+    }
     for (var key in controllers) {
-        if ($(key).length) {
+        // Check if the key have value. Also check if this key exists in the controllerKeys' array
+        // Doing that, you can load non called variables in the web page
+        if ($(key).length || $.inArray(key, controllerKeys) >= 0) {
             controllers[key].forEach(function(js) {
-                if ($.inArray(js, loaded) < 0) {
+                if (all == true || $.inArray(key, controllerKeys) >= 0 || $.inArray(js, _bika_lims_loaded_js) < 0) {
                     console.debug('[bika.lims.loader] Loading '+js);
                     try {
                         obj = new window[js]();
                         obj.load();
                         // Register the object for further access
                         window.bika.lims[js]=obj;
-                        loaded.push(js);
+                        _bika_lims_loaded_js.push(js);
                     } catch (e) {
                        // statements to handle any exceptions
                        var msg = '[bika.lims.loader] Unable to load '+js+": "+ e.message +"\n"+e.stack;
@@ -189,7 +205,8 @@ window.bika.lims.initview = function() {
             });
         }
     }
-    return loaded.length;
+    return _bika_lims_loaded_js.length - prev;
+
 };
 
 window.bika.lims.initialized = false;
@@ -199,7 +216,6 @@ window.bika.lims.initialized = false;
 window.bika.lims.initialize = function() {
     return window.bika.lims.initview();
 };
-
 
 window.jarn.i18n.loadCatalog("bika");
 window.jarn.i18n.loadCatalog("plone");

--- a/bika/lims/browser/js/bika.lims.loader.js
+++ b/bika/lims/browser/js/bika.lims.loader.js
@@ -179,9 +179,6 @@ window.bika.lims.initview = function() {
 window.bika.lims.loadControllers = function(all, controllerKeys) {
     var controllers = window.bika.lims.controllers;
     var prev = _bika_lims_loaded_js.length;
-    if (controllerKeys.length){
-        controllerKeys = controllerKeys.split(",")
-    }
     for (var key in controllers) {
         // Check if the key have value. Also check if this key exists in the controllerKeys' array
         // Doing that, you can load non called variables in the web page

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -7,6 +7,8 @@ from bika.lims.permissions import *
 from bika.lims.utils import to_unicode as _u
 from bika.lims.utils import to_utf8 as _c
 from bika.lims import logger
+from Acquisition import aq_base
+from types import DictType
 from operator import itemgetter
 from Products.Archetypes.Registry import registerWidget
 from Products.Archetypes.Widget import StringWidget
@@ -50,7 +52,8 @@ class ReferenceWidget(StringWidget):
         'sord': 'asc',
         'sidx': 'Title',
         'force_all': True,
-        'portal_types': {}
+        'portal_types': {},
+        'showAddButton': False,
 
     })
     security = ClassSecurityInfo()
@@ -121,6 +124,39 @@ class ReferenceWidget(StringWidget):
         else:
             ret = value.UID() if value else value
         return ret
+
+    def isAddButtonVisible(self):
+        """
+        :return: if the Add image will be shown depending on the shownAddButton field from the schema.
+        """
+        # mode always will be edit, because the function is called from a edit template.
+        mode = 'edit'
+        # Get the default state value
+        state = self.showAddButton
+        # Get the visualisation-mode dic
+        vis_dic = getattr(aq_base(self),'showAddButton')
+        if type(vis_dic) is DictType:
+            state = vis_dic.get(mode, state)
+        elif not vis_dic:
+            state = 'invisible'
+        elif vis_dic < 0:
+            state = 'hidden'
+        return state == 'visible'
+
+    def getAddButtonUrl(self):
+        """
+        :return: URL of the window to display after click the widget's AddButton.
+        """
+        src= self.portal_url()
+        vis_dic = getattr(aq_base(self),'showAddButton')
+        return src + vis_dic.get('addButtonUrl', '')
+
+    def getAddButtonJSControllers(self):
+        """
+        :return: Array with the controllers to be loaded for the layout.
+        """
+        vis_dic = getattr(aq_base(self),'showAddButton')
+        return vis_dic.get('addButtonJSControllers', '')
 
 registerWidget(ReferenceWidget, title='Reference Widget')
 

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -58,8 +58,6 @@ class ReferenceWidget(StringWidget):
             'url': '',
             'js_controllers': [],
             'return_fields': [],
-            'overlay_onLoadJSHelper': '',
-            'overlay_onBeforeCloseJSHelper': '',
             'overlay_options': {},
         },
     })
@@ -137,8 +135,6 @@ class ReferenceWidget(StringWidget):
             'visible': self.add_button.get('visible', False),
             'url': self.add_button.get('url'),
             'return_fields': json.dumps(self.add_button.get('return_fields')),
-            'overlay_onLoadJSHelper': self.add_button.get('overlay_onLoadJSHelper', ''),
-            'overlay_onBeforeCloseJSHelper': self.add_button.get('overlay_onBeforeCloseJSHelper',''),
             'js_controllers': json.dumps(self.add_button.get('js_controllers',[])),
             'overlay_handler': self.add_button.get('overlay_handler', ''),
             'overlay_options': json.dumps(self.add_button.get('overlay_options',{

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -53,8 +53,23 @@ class ReferenceWidget(StringWidget):
         'sidx': 'Title',
         'force_all': True,
         'portal_types': {},
-        'showAddButton': False,
-
+        'add_button': {
+            'visible': False,
+            'url': '',
+            'js_controllers': [],
+            'return_fields': [],
+            'overlay_onLoadJSHelper': '',
+            'overlay_onBeforeCloseJSHelper': '',
+            'overlay_options': {
+                'filter': 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+                'formselector': 'form[id$="base-edit"]',
+                'closeselector': '[name="form.button.cancel"]',
+                'width': '70%',
+                'noform': 'close',
+                'onLoadJSHelper': '',
+                'onCloseJSHelper': '',
+            },
+        },
     })
     security = ClassSecurityInfo()
 
@@ -125,38 +140,16 @@ class ReferenceWidget(StringWidget):
             ret = value.UID() if value else value
         return ret
 
-    def isAddButtonVisible(self):
-        """
-        :return: if the Add image will be shown depending on the shownAddButton field from the schema.
-        """
-        # mode always will be edit, because the function is called from a edit template.
-        mode = 'edit'
-        # Get the default state value
-        state = self.showAddButton
-        # Get the visualisation-mode dic
-        vis_dic = getattr(aq_base(self),'showAddButton')
-        if type(vis_dic) is DictType:
-            state = vis_dic.get(mode, state)
-        elif not vis_dic:
-            state = 'invisible'
-        elif vis_dic < 0:
-            state = 'hidden'
-        return state == 'visible'
-
-    def getAddButtonUrl(self):
-        """
-        :return: URL of the window to display after click the widget's AddButton.
-        """
-        src= self.portal_url()
-        vis_dic = getattr(aq_base(self),'showAddButton')
-        return src + vis_dic.get('addButtonUrl', '')
-
-    def getAddButtonJSControllers(self):
-        """
-        :return: Array with the controllers to be loaded for the layout.
-        """
-        vis_dic = getattr(aq_base(self),'showAddButton')
-        return vis_dic.get('addButtonJSControllers', '')
+    def get_addbutton_options(self):
+        return {
+            'visible': self.add_button.get('visible', False),
+            'url': self.add_button.get('url'),
+            'return_fields': json.dumps(self.add_button.get('return_fields')),
+            'overlay_onLoadJSHelper': self.add_button.get('overlay_onLoadJSHelper', ''),
+            'overlay_onBeforeCloseJSHelper': self.add_button.get('overlay_onBeforeCloseJSHelper',''),
+            'js_controllers': json.dumps(self.add_button.get('js_controllers',[])),
+            'overlay_options': json.dumps(self.add_button.get('overlay_options',{}))
+            }
 
 registerWidget(ReferenceWidget, title='Reference Widget')
 

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -60,15 +60,7 @@ class ReferenceWidget(StringWidget):
             'return_fields': [],
             'overlay_onLoadJSHelper': '',
             'overlay_onBeforeCloseJSHelper': '',
-            'overlay_options': {
-                'filter': 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
-                'formselector': 'form[id$="base-edit"]',
-                'closeselector': '[name="form.button.cancel"]',
-                'width': '70%',
-                'noform': 'close',
-                'onLoadJSHelper': '',
-                'onCloseJSHelper': '',
-            },
+            'overlay_options': {},
         },
     })
     security = ClassSecurityInfo()
@@ -148,7 +140,12 @@ class ReferenceWidget(StringWidget):
             'overlay_onLoadJSHelper': self.add_button.get('overlay_onLoadJSHelper', ''),
             'overlay_onBeforeCloseJSHelper': self.add_button.get('overlay_onBeforeCloseJSHelper',''),
             'js_controllers': json.dumps(self.add_button.get('js_controllers',[])),
-            'overlay_options': json.dumps(self.add_button.get('overlay_options',{}))
+            'overlay_options': json.dumps(self.add_button.get('overlay_options',{
+                'filter': 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+                'formselector': 'form[id$="base-edit"]',
+                'closeselector': '[name="form.button.cancel"]',
+                'width': '70%',
+                'noform': 'close',}))
             }
 
 registerWidget(ReferenceWidget, title='Reference Widget')

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -140,6 +140,7 @@ class ReferenceWidget(StringWidget):
             'overlay_onLoadJSHelper': self.add_button.get('overlay_onLoadJSHelper', ''),
             'overlay_onBeforeCloseJSHelper': self.add_button.get('overlay_onBeforeCloseJSHelper',''),
             'js_controllers': json.dumps(self.add_button.get('js_controllers',[])),
+            'overlay_handler': self.add_button.get('overlay_handler', ''),
             'overlay_options': json.dumps(self.add_button.get('overlay_options',{
                 'filter': 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
                 'formselector': 'form[id$="base-edit"]',

--- a/bika/lims/exportimport/setupdata/__init__.py
+++ b/bika/lims/exportimport/setupdata/__init__.py
@@ -1536,8 +1536,8 @@ class Setup(WorksheetImporter):
             AnalysisAttachmentOption=values[
                 'AnalysisAttachmentOption'][0].lower(),
             DefaultSampleLifetime=DSL,
-            AutoPrintStickers=values['AutoPrintStickers'].lower(),
-            AutoStickerTemplate=values['AutoStickerTemplate'].lower(),
+            AutoPrintStickers=values.get('AutoPrintStickers','receive').lower(),
+            AutoStickerTemplate=values.get('AutoStickerTemplate', 'bika.lims:sticker_small.pt').lower(),
             YearInPrefix=self.to_bool(values['YearInPrefix']),
             SampleIDPadding=int(values['SampleIDPadding']),
             ARIDPadding=int(values['ARIDPadding']),

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -24,6 +24,7 @@ $(document).ready(function(){
     });
     save_UID_check();
     check_UID_check();
+    loadAddButtonOveray();
 });
 
 }(jQuery));
@@ -167,4 +168,63 @@ function check_UID_check(){
             $(this).attr('value',val_chk);
         }
     });
+}
+
+function loadAddButtonOveray() {
+    /**
+     * Add the overlay conditions for the AddButton.
+     */
+    $("a.add_button_overlay").prepOverlay(getOverlayConf());
+}
+
+function getOverlayConf() {
+    /**
+     * Define the overlay configuration parameters.
+     */
+    edit_overlay = {
+        subtype: 'ajax',
+        filter: 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+        formselector: 'form[id$="base-edit"]',
+        closeselector: '[name="form.button.cancel"]',
+        width: '70%',
+        noform:'close',
+        config: {
+            onLoad: function() {
+                // Manually remove remarks
+                this.getOverlay().find("#archetypes-fieldname-Remarks").remove();
+                // Remove menstrual status widget to avoid my suicide
+                // with a "500 service internal error"
+                this.getOverlay().find("#archetypes-fieldname-MenstrualStatus").remove();
+
+                // Force to reload bika.lims.initalize method with the needed overlay's health controllers.
+                // This is done to work with specific js and widgets in the overlay.
+                if ($("a.add_button_overlay").attr("data_js_controllers")){
+                    window.bika.lims.loadControllers(false,$("a.add_button_overlay").attr("data_js_controllers"));
+                }
+                // Address widget
+                $.ajax({
+                    url: 'bika_widgets/addresswidget.js',
+                    dataType: 'script',
+                    async: false
+                });
+            },
+            onBeforeClose: function() {
+                // Fill the box with the recently created object
+                var name = $('#Firstname').val() + ' ' + $("#Surname").val();
+                if ($('#Firstname').val() == undefined) {
+                    name = $('#title').val();
+                }
+                var overlay_trigger = $('div.overlay').overlay().getTrigger().attr("id");
+                var trigger_id = $("[rel='#" + overlay_trigger + "']").attr('id').replace('_addButtonOverlay','');
+                if (name.length > 1) {
+                    $('#' + trigger_id).val(name).focus();
+                    setTimeout(function() {
+                        $('.cg-DivItem').first().click();
+                    }, 500);
+                }
+                setTimeout(function() {return true; 100;});
+            }
+        }
+    };
+    return edit_overlay;
 }

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -187,7 +187,7 @@ function load_addbutton_overlays() {
             if (jscontrollers.length > 0) {
                 window.bika.lims.loadControllers(false, jscontrollers);
             }
-            var jshelper = $(triggerid).attr('data_onload_jshelper');
+            /*var jshelper = $(triggerid).attr('data_onload_jshelper');
             if (jshelper != '') {
                 console.debug("[Overlay] Loading "+jshelper);
                 $.ajax({
@@ -195,6 +195,16 @@ function load_addbutton_overlays() {
                     dataType: 'script',
                     async: false
                 });
+            }*/
+            var handler = $(triggerid).attr('data_overlay_handler');
+            if (handler != '') {
+                var fn = window[handler];
+                if (typeof fn === "function") {
+                    obj = obj();
+                    if (typeof obj.onLoad === "function") {
+                        obj.onLoad.apply(this);
+                    }
+                }
             }
         }
 

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.pt
@@ -101,6 +101,18 @@
                                  ui_item widget/ui_item;
                                  combogrid_options python:widget.get_combogrid_options(context, fieldName)"
                  />
+            <span tal:condition="widget/isAddButtonVisible">
+                <!-- Condition to add quick-add-button -->
+                <a style="border-bottom:none !important;margin-left:.5;"
+                   class="add_button_overlay"
+                   tal:attributes="
+                           id python:fieldName+'_addButtonOverlay';
+                           href widget/getAddButtonUrl;
+                           data_js_controllers widget/getAddButtonJSControllers"
+                   rel="#overlay">
+                    <img style="padding-bottom:1px;" src="++resource++bika.lims.images/add.png"/>
+                </a>
+            </span>
           <input
                  type="hidden"
                  name=""

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.pt
@@ -110,6 +110,7 @@
                                href string:${portal/absolute_url}/${options/url};
                                data_fieldid fieldName;
                                data_fieldname fieldName;
+                               data_overlay_handler options/overlay_handler;
                                data_onload_jshelper options/overlay_onLoadJSHelper;
                                data_onbeforeclose_jshelper options/overlay_onBeforeCloseJSHelper;
                                data_returnfields options/return_fields;

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.pt
@@ -111,8 +111,6 @@
                                data_fieldid fieldName;
                                data_fieldname fieldName;
                                data_overlay_handler options/overlay_handler;
-                               data_onload_jshelper options/overlay_onLoadJSHelper;
-                               data_onbeforeclose_jshelper options/overlay_onBeforeCloseJSHelper;
                                data_returnfields options/return_fields;
                                data_jscontrollers options/js_controllers;
                                data_overlay options/overlay_options">

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.pt
@@ -39,7 +39,7 @@
                       class="deletebtn"
                       tal:attributes="
                         src string:${portal/absolute_url}/++resource++bika.lims.images/delete.png;
-                      	fieldName fieldName;
+                        fieldName fieldName;
                         uid value/UID"/>
                     <span tal:replace="python:str(value.Title())"/>
                   </div>
@@ -101,18 +101,22 @@
                                  ui_item widget/ui_item;
                                  combogrid_options python:widget.get_combogrid_options(context, fieldName)"
                  />
-            <span tal:condition="widget/isAddButtonVisible">
-                <!-- Condition to add quick-add-button -->
-                <a style="border-bottom:none !important;margin-left:.5;"
-                   class="add_button_overlay"
-                   tal:attributes="
-                           id python:fieldName+'_addButtonOverlay';
-                           href widget/getAddButtonUrl;
-                           data_js_controllers widget/getAddButtonJSControllers"
-                   rel="#overlay">
-                    <img style="padding-bottom:1px;" src="++resource++bika.lims.images/add.png"/>
-                </a>
-            </span>
+            <a rel='#overlay'
+               class='add-button referencewidget-add-button',
+               tal:define="options python:widget.get_addbutton_options()"
+               tal:condition="options/visible"
+               tal:attributes="name python:fieldName+'_addbutton';
+                               id   python:fieldName+'_addbutton';
+                               href string:${portal/absolute_url}/${options/url};
+                               data_fieldid fieldName;
+                               data_fieldname fieldName;
+                               data_onload_jshelper options/overlay_onLoadJSHelper;
+                               data_onbeforeclose_jshelper options/overlay_onBeforeCloseJSHelper;
+                               data_returnfields options/return_fields;
+                               data_jscontrollers options/js_controllers;
+                               data_overlay options/overlay_options">
+                    <span class='notext' i18n:translate="">Add</span>
+            </a>
           <input
                  type="hidden"
                  name=""

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1000,10 +1000,20 @@ div.warnbox h3 {
 a.add-button {
     font-weight: bold;
     background: transparent url(&dtml-portal_url;/++resource++bika.lims.images/add.png) left center no-repeat;
+    height: 16px;
+    width: 16px;
+}
+#content a.add-button.referencewidget-add-button.link-overlay {
+    border-bottom: medium none !important;
 }
 h2 a.add-button {
     padding: 12px 0 0 38px;
     background-position: 15px 10px;
+}
+.notext {
+    overflow: hidden;
+    visibility:hidden;
+    display:none;
 }
 #portal-alert {
     background: url(&dtml-portal_url;/++resource++bika.lims.images/warning_big.png) no-repeat scroll 20px 15px #FFF680;


### PR DESCRIPTION
**This other PR should be reviewed and accepted or rejected at the same time**: http://git.io/tb3cjQ

**Basic usage**
```python
ExtReferenceField(
            'Doctor',
            # ... other stuff ....
            widget=ReferenceWidget(
               # ... other stuff ...
                add_button={
                    'visible': True,
                    'url': 'doctors/portal_factory/Doctor/new/edit',
                    'return_fields': ['Firstname', 'Surname'],
                }
            ),
        ),
```

url: the url to be loaded inside the overlay
return_fields: the fields to be used to fill the referencewidget after the submit

**Advanced usage**
```python
ExtReferenceField(
            'Patient',
            # ... other stuff ....
            widget=ReferenceWidget(
                # ... other stuff ....
                add_button={
                    'visible': True,
                    'url': 'patients/portal_factory/Patient/new/edit',
                    'return_fields': ['Firstname', 'Surname'],
                    'js_controllers': ['#patient-base-edit',],
                    'overlay_handler': 'HealthPatientOverlayHandler',
                }
            ),
        ),
```
js_controllers: the controllers we need to load specifically for the view to be loaded inside the overlay
In this case, a specific js handler is required (overlay_handler) to manage the overlay event, so we need to add it:
https://github.com/xispa/bika.health/blob/issue/HEALTH-136/bika/health/static/js/bika.health.patient.js#L440-L472
Easy!

**Expert usage**
```javascript
add_button={
    'visible': True,
    'url': 'patients/portal_factory/Patient/new/edit',
    'return_fields': ['Firstname', 'Surname'],
    'js_controllers': ['#patient-base-edit',],
    'overlay_handler': 'HealthPatientOverlayHandler',
    'overlay_options': {
        'filter': 'head>*,content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
        'formselector': 'form[id$="base-edit"]',
        'closeselector': '[name="form.button.cancel"]',
        'width': '70%',
        'noform': 'close',
    },
```
}