### PR TITLE
Issue/1614  Error when selecting Analysis Administration Tab after receiving a sample with Sampling Workflow enabled

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -16,6 +16,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n.locales import locales
 from zope.interface import implements
+import traceback
 
 import json
 import plone
@@ -109,9 +110,14 @@ class AnalysisRequestAnalysesView(BikaListingView):
         rr = self.context.getResultsRange()
         for r in rr:
             keyword = r['keyword']
-            service_uid = bsc(portal_type='AnalysisService',
-                              getKeyword=keyword)[0].UID
-            rr_dict_by_service_uid[service_uid] = r
+            try:
+                service_uid = bsc(portal_type='AnalysisService',
+                                  getKeyword=keyword)[0].UID
+                rr_dict_by_service_uid[service_uid] = r
+            except IndexError:
+                print "Not existent ", keyword
+                print traceback.format_exc()
+
         return json.dumps(rr_dict_by_service_uid)
 
     def get_spec_from_ar(self, ar, keyword):

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -16,7 +16,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n.locales import locales
 from zope.interface import implements
-import traceback
 
 import json
 import plone
@@ -115,8 +114,11 @@ class AnalysisRequestAnalysesView(BikaListingView):
                                   getKeyword=keyword)[0].UID
                 rr_dict_by_service_uid[service_uid] = r
             except IndexError:
-                print "Not existent ", keyword
-                print traceback.format_exc()
+                from bika.lims import logger
+                error = "Non existent '%s' keyword in the catalog. This AS has been modified, but the Results Range " \
+                        "dict has not been changed yet. The issue has not been resolved yet: " \
+                        "https://jira.bikalabs.com/browse/LIMS-1614"
+                logger.exception(error, keyword)
 
         return json.dumps(rr_dict_by_service_uid)
 


### PR DESCRIPTION
...ing a sample with Sampling Workflow enabled

Preventive try-catch: When you change the keyword from an Analysis Specification, the ResultsRange doesn't change the keyword value. This generates an error while broswer/analysisrequest/getResultsRange() is searching AS' UID with the keyword.

https://jira.bikalabs.com/browse/LIMS-1614
http://sentry.bikalabs.com/bikalims/dev-demo-test/group/4920/