### PR TITLE
shashattr instead of hasattr - avoid acquisition.

### DIFF
--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -146,7 +146,7 @@ class ARAnalysesField(ObjectField):
                 interim_fields.append(v)
 
             # create the analysis if it doesn't exist
-            if hasattr(instance, keyword):
+            if shasattr(instance, keyword):
                 analysis = instance._getOb(keyword)
             else:
                 analysis = create_analysis(


### PR DESCRIPTION
One of my test sites is called 'asdf'.  Then, I made a service with
keyword 'asdf'.  Suddenly this code thought that my site object was
a service, since 'asdf' is an attribute of the root.