### PR TITLE
defend against nonexistent landing_page in registry

### DIFF
--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -105,7 +105,10 @@ class ClientFolderContentsView(BikaListingView):
         self.contentsMethod = self.getClientList
         items = BikaListingView.folderitems(self)
         registry = getUtility(IRegistry)
-        landing_page = registry['bika.lims.client.default_landing_page']
+        if 'bika.lims.client.default_landing_page' in registry:
+            landing_page = registry['bika.lims.client.default_landing_page']
+        else:
+            landing_page = 'analysisrequests'
         for x in range(len(items)):
             if not items[x].has_key('obj'): continue
             obj = items[x]['obj']

--- a/bika/lims/skins/bika/logged_in.cpy
+++ b/bika/lims/skins/bika/logged_in.cpy
@@ -44,7 +44,11 @@ membership_tool.loginUser(REQUEST)
 
 client = logged_in_client(context, member)
 registry = getUtility(IRegistry)
-landing_page = registry['bika.lims.client.default_landing_page']
+if 'bika.lims.client.default_landing_page' in registry:
+    landing_page = registry['bika.lims.client.default_landing_page']
+else:
+    landing_page = 'analysisrequests'
+
 if client:
     url = client.absolute_url() + "/" + landing_page
     return context.REQUEST.response.redirect(url)


### PR DESCRIPTION
Before upgrade, this key will not exist, and login will "fail"
until migration has happened.

@zylinx fyi.