### PR TITLE
LIMS-1696 Decimal mark conversion is not working with "<0,002" results type

### DIFF
--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -592,7 +592,7 @@ class Analysis(BaseContent):
         try:
             result = float(result)
         except:
-            return result
+            return formatDecimalMark(result, decimalmark=decimalmark)
 
         # 3. If the analysis specs has enabled hidemin or hidemax and the
         #    result is out of range, render result as '<min' or '>max'

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,6 @@
 3.1.7 (2015-02-26)
 ------------------
-
+LIMS-1696: Decimal mark conversion is not working with "<0,002" results type
 LIMS-1520: Allow to invalidate verified ARs
 LIMS-1690: Typo. Instrument page
 LIMS-1688: After AR invalidation, ARs list throws an error


### PR DESCRIPTION
Small fix for 3.1.7