### PR TITLE
Adding a fix for the "ImportError: cannot import name Retract".

### DIFF
--- a/bika/lims/skins/bika/guard_retract_transition.py
+++ b/bika/lims/skins/bika/guard_retract_transition.py
@@ -8,7 +8,7 @@
 ##title=
 ##
 
-from bika.lims import Retract
+from bika.lims.permissions import Retract
 
 workflow = context.portal_workflow
 checkPermission = context.portal_membership.checkPermission


### PR DESCRIPTION
- This error arose when upgrading bika from 3.1.6 to 3.1.7 and then trying to view all the Analysis Requests.