### PR TITLE
Fix error when running bin/buildout

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -72,7 +72,9 @@ eggs = bika.lims [test]
 
 [robot]
 recipe = zc.recipe.egg
-eggs = ${buildout:eggs} plone.app.robotframework
+eggs =
+    ${buildout:eggs}
+    plone.app.robotframework
 
 [omelette]
 recipe = collective.recipe.omelette


### PR DESCRIPTION
Running bin/buildout gives error when installing robot. Traceback: http://pastie.org/10060732 . This is fixed by splitting 'eggs' in [robot] section into three lines, separating 'eggs', 'buildout:eggs' and 'robotframework'.

The fix is manually tested to work with virtualenv in Ubuntu 14.04. 'bin/buildout ran without previously mentioned errors.