### PR TITLE
[LIMS-1737] Fixed error in adding pricelists

### DIFF
--- a/bika/lims/content/pricelist.py
+++ b/bika/lims/content/pricelist.py
@@ -127,14 +127,13 @@ def ObjectModifiedEventHandler(instance, event):
             itemDescription = None
             itemAccredited = False
             if instance.getType() == "LabProduct":
-                if obj.getVolume() or obj.getUnit():
-                    print_detail = " ("
+                print_detail = ""
                 if obj.getVolume():
                     print_detail = print_detail + str(obj.getVolume())
                 if obj.getUnit():
                     print_detail = print_detail + str(obj.getUnit())
-                if print_detail:
-                    print_detail = print_detail + ")"
+                if obj.getVolume() or obj.getUnit():
+                    print_detail = " (" + print_detail + ")"
                     itemTitle = obj.Title() + print_detail
                 else:
                     itemTitle = obj.Title()


### PR DESCRIPTION
If a lab product had no unit and volume, creating a pricelist for lab products gave an error that 'print_detail' was not referenced. This was fixed by initializing print_detail and shifting a case accordingly.

The modified version had been manually tested and creating pricelist of lab products with and without volume and unit was successful.