### PR TITLE
[LIMS-1724] Fixed dates on reports

### DIFF
--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -154,10 +154,10 @@ class SelectionMacrosView(BrowserView):
 
         if from_date and to_date:
             parms = translate(_("From ${start_date} to ${end_date}",
-                               mapping={"start":from_date, "end":to_date}))
+                               mapping={"start_date":from_date, "end_date":to_date}))
         elif from_date:
             parms = translate(_("Before ${start_date}",
-                               mapping={"start":from_date}))
+                               mapping={"start_date":from_date}))
         elif to_date:
             parms = translate(_("After ${end_date}",
                                mapping={"end_date":to_date}))

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2 (unreleased)
 ----------------
+LIMS-1724 Fixed missing start and end dates in reports
 LIMS-1675 WorkOrder tabs not showing when its WorkSheets tab is open
 LIMS-1674 AR create inside WorkOrders does not save
 LIMS-1669 Worksheet lists and creation inside Batches/WorkOrders


### PR DESCRIPTION
In reports, instead of start dates and end dates, '${start_date}' and '${end_date}' are being shown. This is because of a mistake in mapping.

The issue is fixed and is manually tested by generating report of received samples. The report now shows both start dates and end dates or any of them individually.