### PR TITLE
LIMS-1738: Regression. 'NoneType' object has no attribute 'getResultsRangeDict'

### DIFF
--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -318,7 +318,7 @@ class Analysis(BaseContent):
                 return rr
 
         specs = an.getAnalysisSpecs(specification)
-        rr = specs.getResultsRangeDict()
+        rr = specs.getResultsRangeDict() if specs else {}
         rr = rr.get(an.getKeyword(), {}) if rr else {}
         if rr:
             rr['uid'] = self.UID()

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1738: Regression. 'NoneType' object has no attribute 'getResultsRangeDict'
 LIMS-1628: There should be a results interpretation field per lab department
 LIMS-1696: Decimal mark conversion is not working with "<0,002" results type
 LIMS-1729: Analysis Specification Not applying to Sample when Selected


### PR DESCRIPTION
Due to some code refactoring done for [LIMS-1729 Analysis Specification Not applying to Sample when Selected](https://jira.bikalabs.com/browse/LIMS-1729)

```
Traceback (innermost last):
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module bika.lims.browser.analysisrequest.manage_results, line 49, in _call_
Module bika.lims.browser.bika_listing, line 786, in contents_table
Module bika.lims.browser.bika_listing, line 875, in _init_
Module bika.lims.browser.analyses, line 591, in folderitems
Module bika.lims.browser.analyses, line 139, in get_analysis_spec
Module bika.lims.content.analysis, line 321, in getResultsRange
AttributeError: 'NoneType' object has no attribute 'getResultsRangeDict'
```