### PR TITLE
LIMS-1748 Fixed error in adding supply order

### DIFF
--- a/bika/lims/browser/supplyorder.py
+++ b/bika/lims/browser/supplyorder.py
@@ -110,6 +110,8 @@ class EditView(BrowserView):
             self.products = []
             products = sorted(products, key = methodcaller('Title'))
             for product in products:
+                if not product.getPrice():
+                    continue
                 item = [o for o in items if o['Product'] == product.getId()]
                 quantity = item[0]['Quantity'] if len(item) > 0 else 0
                 self.products.append({

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.8 (unreleased)
 ------------------
 
+LIMS-1748: Error in adding supply order when a product has no price
 LIMS-1745: Retracted analyses in duplicates
 LIMS-1629: Pdf reports should split analysis results in different pages according to the lab department
 Some new ID Generator's features, as the possibility of select the separator type


### PR DESCRIPTION
The supply order gives the error when there is a product with no price given. Price is not a mandatory field for products. The fix allows the supply order to neglect such products because price is required when supply order is created. [LIMS-1748](https://jira.bikalabs.com/browse/LIMS-1748).