### PR TITLE
LIMS-1324 Allow to hide analyses in results reports

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -45,6 +45,9 @@ class AnalysisRequestAnalysesView(BikaListingView):
             'Title': {'title': _('Service'),
                       'index': 'sortable_title',
                       'sortable': False, },
+            'Hidden': {'title': _('Hidden'),
+                       'sortable': False,
+                       'type': 'boolean', },
             'Price': {'title': _('Price'),
                       'sortable': False, },
             'Priority': {'title': _('Priority'),
@@ -58,7 +61,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             'error': {'title': _('Permitted Error %')},
         }
 
-        columns = ['Title', ]
+        columns = ['Title', 'Hidden', ]
         ShowPrices = self.context.bika_setup.getShowPrices()
         if ShowPrices:
             columns.append('Price')
@@ -249,6 +252,12 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 )
             if after_icons:
                 items[x]['after']['Title'] = after_icons
+
+
+            # Display analyses for this Analysis Service in results?
+            ser = self.context.getAnalysisServiceSettings(obj.UID())
+            items[x]['allow_edit'] = ['Hidden', ]
+            items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
 
         self.categories.sort()
         return items

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -26,7 +26,7 @@
                                 tal:content="python:format['title']"></option>
                     </tal:formats>
                 </select>
-                <a href='#' id='sel_format_info'><img tal:attributes='src python:portal.absolute_url()+"/++resource++bika.lims.images/info.png";'/></a>
+                <a href='#' id='sel_format_info'><img tal:attributes='src python:portal.absolute_url()+"/++resource++bika.lims.images/info.png";'/></a><br/>
                 <input type="checkbox" name="qcvisible" id='qcvisible' value="0"><span i18n:translate="">Show QC Analyses</span><br/>
                 <input type="checkbox" name="hvisible" id='hvisible' value="0"><span i18n:translate="">Show Hidden Analyses</span>
             </div>
@@ -68,6 +68,9 @@
             }
             #ar_publish_header #options_handler label {
                 padding:5px 10px 5px 10px;
+            }
+            #ar_publish_header #options_handler input {
+                padding:5px 10px 0px;
             }
             #ar_publish_header #ar_publish_summary {
                 padding-left:10px;

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -27,7 +27,8 @@
                     </tal:formats>
                 </select>
                 <a href='#' id='sel_format_info'><img tal:attributes='src python:portal.absolute_url()+"/++resource++bika.lims.images/info.png";'/></a>
-                <input type="checkbox" name="qcvisible" id='qcvisible' value="0"><span i18n:translate="">Show QC Analyses</span>
+                <input type="checkbox" name="qcvisible" id='qcvisible' value="0"><span i18n:translate="">Show QC Analyses</span><br/>
+                <input type="checkbox" name="hvisible" id='hvisible' value="0"><span i18n:translate="">Show Hidden Analyses</span>
             </div>
             <div id="sel_format_info_pane" style="display:none">
                 <p i18n:translate="">Refer to <a target="_blank" href="https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates">Creating new report templates</a> documentation from Bika LIMS wiki to get more or add your own report templates.</p>

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -112,6 +112,17 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
             return
         Analyses = objects.keys()
         prices = form.get("Price", [None])[0]
+
+        # Hidden analyses?
+        # https://jira.bikalabs.com/browse/LIMS-1324
+        outs = []
+        hiddenans = form.get('Hidden', {})
+        for uid in Analyses:
+            hidden = hiddenans.get(uid, '')
+            hidden = True if hidden == 'on' else False
+            outs.append({'uid':uid, 'hidden':hidden})
+        ar.setAnalysisServicesSettings(outs)
+
         specs = {}
         if form.get("min", None):
             for service_uid in Analyses:
@@ -142,6 +153,8 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
                 analysis = ar[service.getKeyword()]
                 analysis.setSamplePartition(part)
                 analysis.reindexObject()
+        self.review_states[0]['columns'].insert(1, 'Hidden')
+
         if new:
             for analysis in new:
                 # if the AR has progressed past sample_received, we need to bring it back.

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -153,7 +153,6 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
                 analysis = ar[service.getKeyword()]
                 analysis.setSamplePartition(part)
                 analysis.reindexObject()
-        self.review_states[0]['columns'].insert(1, 'Hidden')
 
         if new:
             for analysis in new:

--- a/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
@@ -48,49 +48,22 @@ function AnalysisRequestPublishView() {
         });
 
         $('#sel_format').change(function(e) {
-            var url = window.location.href;
-            var seltpl = $(this).val();
-            $('#report').animate({opacity:0.4}, 'slow');
-            $.ajax({
-                url: url,
-                type: 'POST',
-                async: false,
-                data: { "template":seltpl}
-            })
-            .always(function(data) {
-                var htmldata = data;
-                cssdata = $(htmldata).find('#report-style').html();
-                $('#report-style').html(cssdata);
-                htmldata = $(htmldata).find('#report').html();
-                $('#report').html(htmldata);
-                $('#report').animate({opacity:1}, 'slow');
-                load_barcodes();
-            });
+            reloadReport();
         });
 
         $('#qcvisible').click(function(e) {
-            var url = window.location.href;
-            if ($('#qcvisible').is(':checked')) {
-                url += url.indexOf('?') >= 0 ? "&qcvisible=1" : "?qcvisible=1";
-            }
-            $('#report').animate({opacity:0.4}, 'slow');
-            $.ajax({
-                url: url,
-                type: 'GET',
-                success: function(data, textStatus, $XHR){
-                    var htmldata = data;
-                    htmldata = $(htmldata).find('#report').html();
-                    $('#report').html(htmldata);
-                    $('#report').animate({opacity:1}, 'slow');
-                    load_barcodes();
-                }
-            });
+            reloadReport();
+        });
+
+        $('#hvisible').click(function(e) {
+            reloadReport();
         });
 
         $('#publish_button').click(function(e) {
             var url = window.location.href;
             var qcvisible = $('#qcvisible').is(':checked') ? 1 : 0;
-            var template = $('#self_format').val();
+            var hvisible = $('#hvisible').is(':checked') ? 1 : 0;
+            var template = $('#sel_format').val();
             $('#ar_publish_container').animate({opacity:0.4}, 'slow');
             var count = $('#ar_publish_container #report .ar_publish_body').length;
             $('#ar_publish_container #report .ar_publish_body').each(function(){
@@ -99,11 +72,14 @@ function AnalysisRequestPublishView() {
                 $.ajax({
                     url: url,
                     type: 'POST',
-                    async: false,
+                    async: true,
                     data: { "publish":1,
                             "id":$(this).attr('id'),
                             "uid":$(this).attr('uid'),
                             "html": rephtml,
+                            "template": template,
+                            "qcvisible": qcvisible,
+                            "hvisible": hvisible,
                             "style": repstyle}
                 })
                 .always(function(){
@@ -150,6 +126,32 @@ function AnalysisRequestPublishView() {
                             {'barHeight': parseInt(barHeight),
                              'addQuietZone': Boolean(addQuietZone),
                              'showHRI': Boolean(showHRI) });
+        });
+    }
+
+    function reloadReport() {
+        var url = window.location.href;
+        var template = $('#sel_format').val();
+        var qcvisible = $('#qcvisible').is(':checked') ? '1' : '0';
+        var hvisible = $('#hvisible').is(':checked') ? '1' : '0';
+        $('#report').fadeTo('fast', 0.4);
+        //$('#report').animate({opacity:0.4}, 'slow');
+        $.ajax({
+            url: url,
+            type: 'POST',
+            async: true,
+            data: { "template": template,
+                    "qcvisible": qcvisible,
+                    "hvisible": hvisible}
+        })
+        .always(function(data) {
+            var htmldata = data;
+            cssdata = $(htmldata).find('#report-style').html();
+            $('#report-style').html(cssdata);
+            htmldata = $(htmldata).find('#report').html();
+            $('#report').html(htmldata);
+            $('#report').fadeTo('fast', 1);
+            load_barcodes();
         });
     }
 }

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -162,10 +162,11 @@ class AnalysisProfileAnalysesWidget(TypesWidget):
             # Hidden analyses?
             outs = []
             hiddenans = form.get('Hidden', {})
-            for uid in service_uids:
-                hidden = hiddenans.get(uid, '')
-                hidden = True if hidden == 'on' else False
-                outs.append({'uid':uid, 'hidden':hidden})
+            if service_uids:
+                for uid in service_uids:
+                    hidden = hiddenans.get(uid, '')
+                    hidden = True if hidden == 'on' else False
+                    outs.append({'uid':uid, 'hidden':hidden})
             instance.setAnalysisServicesSettings(outs)
 
         return service_uids, {}

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -34,6 +34,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
         self.pagesize = 0
         self.allow_edit = allow_edit
         self.form_id = "analyses"
+        self.profile = None
 
         self.columns = {
             'Title': {'title': _('Service'),
@@ -56,6 +57,17 @@ class AnalysisProfileAnalysesView(BikaListingView):
 
         self.fieldvalue = fieldvalue
         self.selected = [x.UID() for x in fieldvalue]
+
+        if self.aq_parent.portal_type == 'AnalysisProfile':
+            # Custom settings for the Analysis Services assigned to
+            # the Analysis Profile
+            # https://jira.bikalabs.com/browse/LIMS-1324
+            self.profile = self.aq_parent
+            self.columns['Hidden'] = {'title': _('Hidden'),
+                                      'sortable': False,
+                                      'type': 'boolean'}
+            self.review_states[0]['columns'].insert(1, 'Hidden')
+
 
     def folderitems(self):
         self.categories = []
@@ -116,6 +128,13 @@ class AnalysisProfileAnalysesView(BikaListingView):
                               _('Attachment not permitted'))
             if after_icons:
                 items[x]['after']['Title'] = after_icons
+
+            if self.profile:
+                # Display analyses for this Analysis Service in results?
+                ser = self.profile.getAnalysisServiceSettings(obj.UID())
+                items[x]['allow_edit'] = ['Hidden', ]
+                items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
+
         self.categories.sort()
         return items
 
@@ -138,6 +157,17 @@ class AnalysisProfileAnalysesWidget(TypesWidget):
         bsc = getToolByName(instance, 'bika_setup_catalog')
         value = []
         service_uids = form.get('uids', None)
+
+        if instance.portal_type == 'AnalysisProfile':
+            # Hidden analyses?
+            outs = []
+            hiddenans = form.get('Hidden', {})
+            for uid in service_uids:
+                hidden = hiddenans.get(uid, '')
+                hidden = True if hidden == 'on' else False
+                outs.append({'uid':uid, 'hidden':hidden})
+            instance.setAnalysisServicesSettings(outs)
+
         return service_uids, {}
 
     security.declarePublic('Analyses')

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -190,10 +190,11 @@ class ARTemplateAnalysesWidget(TypesWidget):
             # Hidden analyses?
             outs = []
             hiddenans = form.get('Hidden', {})
-            for uid in service_uids:
-                hidden = hiddenans.get(uid, '')
-                hidden = True if hidden == 'on' else False
-                outs.append({'uid':uid, 'hidden':hidden})
+            if service_uids:
+                for uid in service_uids:
+                    hidden = hiddenans.get(uid, '')
+                    hidden = True if hidden == 'on' else False
+                    outs.append({'uid':uid, 'hidden':hidden})
             instance.setAnalysisServicesSettings(outs)
 
         return value, {}

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -60,6 +60,16 @@ class ARTemplateAnalysesView(BikaListingView):
         self.fieldvalue = fieldvalue
         self.selected = [x['service_uid'] for x in fieldvalue]
 
+        if self.aq_parent.portal_type == 'ARTemplate':
+            # Custom settings for the Analysis Services assigned to
+            # the Analysis Request Template
+            # https://jira.bikalabs.com/browse/LIMS-1324
+            self.artemplate = self.aq_parent
+            self.columns['Hidden'] = {'title': _('Hidden'),
+                                      'sortable': False,
+                                      'type': 'boolean'}
+            self.review_states[0]['columns'].insert(1, 'Hidden')
+
     def folderitems(self):
         self.categories = []
 
@@ -137,6 +147,13 @@ class ARTemplateAnalysesView(BikaListingView):
                               _('Attachment not permitted'))
             if after_icons:
                 items[x]['after']['Title'] = after_icons
+
+            if self.artemplate:
+                # Display analyses for this Analysis Service in results?
+                ser = self.artemplate.getAnalysisServiceSettings(obj.UID())
+                items[x]['allow_edit'] = ['Hidden', ]
+                items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
+
         self.categories.sort()
         return items
 
@@ -168,6 +185,17 @@ class ARTemplateAnalysesWidget(TypesWidget):
                    and Partitions[service_uid] != '':
                     value.append({'service_uid':service_uid,
                                   'partition':Partitions[service_uid]})
+
+        if instance.portal_type == 'ARTemplate':
+            # Hidden analyses?
+            outs = []
+            hiddenans = form.get('Hidden', {})
+            for uid in service_uids:
+                hidden = hiddenans.get(uid, '')
+                hidden = True if hidden == 'on' else False
+                outs.append({'uid':uid, 'hidden':hidden})
+            instance.setAnalysisServicesSettings(outs)
+
         return value, {}
 
     security.declarePublic('Analyses')

--- a/bika/lims/content/analysisprofile.py
+++ b/bika/lims/content/analysisprofile.py
@@ -78,12 +78,35 @@ class AnalysisProfile(BaseContent):
         return self.aq_parent.UID();
 
     def getAnalysisServiceSettings(self, uid):
+        """ Returns a dictionary with the settings for the analysis
+            service that match with the uid provided.
+            If there are no settings for the analysis service and
+            profile, returns a dictionary with the key 'uid'
+        """
         sets = [s for s in self.getAnalysisServicesSettings() \
                 if s.get('uid','') == uid]
         return sets[0] if sets else {'uid': uid}
 
     def isAnalysisServiceHidden(self, uid):
+        """ Checks if the analysis service that match with the uid
+            provided must be hidden in results.
+            If no hidden assignment has been set for the analysis in
+            this profile, returns the visibility set to the analysis
+            itself.
+            Raise a TypeError if the uid is empty or None
+            Raise a ValueError if there is no hidden assignment in this
+                profile or no analysis service found for this uid.
+        """
+        if not uid:
+            raise TypeError('None type or empty uid')
         sets = self.getAnalysisServiceSettings(uid)
+        if 'hidden' not in sets:
+            uc = getToolByName(self, 'uid_catalog')
+            serv = uc(UID=uid)
+            if serv and len(serv) == 1:
+                return serv[0].getObject().getRawHidden()
+            else:
+                raise ValueError('%s is not valid' % uid)
         return sets.get('hidden', False)
 
 registerType(AnalysisProfile, PROJECTNAME)

--- a/bika/lims/content/analysisprofile.py
+++ b/bika/lims/content/analysisprofile.py
@@ -82,4 +82,8 @@ class AnalysisProfile(BaseContent):
                 if s.get('uid','') == uid]
         return sets[0] if sets else {'uid': uid}
 
+    def isAnalysisServiceHidden(self, uid):
+        sets = self.getAnalysisServiceSettings(uid)
+        return sets.get('hidden', False)
+
 registerType(AnalysisProfile, PROJECTNAME)

--- a/bika/lims/content/analysisprofile.py
+++ b/bika/lims/content/analysisprofile.py
@@ -11,6 +11,7 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from Products.Archetypes.public import *
 from Products.Archetypes.references import HoldingReference
+from Products.ATExtensions.field import RecordsField
 from Products.CMFCore.permissions import View, ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
 from zope.interface import Interface, implements
@@ -47,6 +48,16 @@ schema = BikaSchema.copy() + Schema((
             append_only = True,
         ),
     ),
+    # Custom settings for the assigned analysis services
+    # https://jira.bikalabs.com/browse/LIMS-1324
+    # Fields:
+    #   - uid: Analysis Service UID
+    #   - hidden: True/False. Hide/Display in results reports
+    RecordsField('AnalysisServicesSettings',
+         required=0,
+         subfields=('uid', 'hidden',),
+         widget=ComputedWidget(visible=False),
+    ),
 ),
 )
 schema['title'].widget.visible = True
@@ -65,5 +76,10 @@ class AnalysisProfile(BaseContent):
 
     def getClientUID(self):
         return self.aq_parent.UID();
+
+    def getAnalysisServiceSettings(self, uid):
+        sets = [s for s in self.getAnalysisServicesSettings() \
+                if s.get('uid','') == uid]
+        return sets[0] if sets else {'uid': uid}
 
 registerType(AnalysisProfile, PROJECTNAME)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1250,6 +1250,16 @@ schema = BikaSchema.copy() + Schema((
                            'richtext': _('Results Interpreation'),},
         widget = RichWidget(visible=False),
     ),
+    # Custom settings for the assigned analysis services
+    # https://jira.bikalabs.com/browse/LIMS-1324
+    # Fields:
+    #   - uid: Analysis Service UID
+    #   - hidden: True/False. Hide/Display in results reports
+    RecordsField('AnalysisServicesSettings',
+         required=0,
+         subfields=('uid', 'hidden',),
+         widget=ComputedWidget(visible=False),
+    ),
 )
 )
 
@@ -2031,6 +2041,24 @@ class AnalysisRequest(BaseFolder):
         else:
             row = {'uid': uid, 'richtext': ''};
         return row
+
+    def getAnalysisServiceSettings(self, uid):
+        sets = [s for s in self.getAnalysisServicesSettings() \
+                if s.get('uid','') == uid]
+
+        # Created by using an ARTemplate?
+        if not sets and self.getTemplate():
+            adv = self.getTemplate().getAnalysisServiceSettings(uid)
+            if adv.get('hidden'):
+                sets = [adv]
+
+        # Created by using an AR Profile?
+        if not sets and self.getProfile():
+            adv = self.getProfile().getAnalysisServiceSettings(uid)
+            if adv.get('hidden'):
+                sets = [adv]
+
+        return sets[0] if sets else {'uid': uid}
 
     def guard_unassign_transition(self):
         """Allow or disallow transition depending on our children's states

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2058,6 +2058,10 @@ class AnalysisRequest(BaseFolder):
 
         return sets[0] if sets else {'uid': uid}
 
+    def isAnalysisServiceHidden(self, uid):
+        sets = self.getAnalysisServiceSettings(uid)
+        return sets.get('hidden', False)
+
     def guard_unassign_transition(self):
         """Allow or disallow transition depending on our children's states
         """

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2049,14 +2049,12 @@ class AnalysisRequest(BaseFolder):
         # Created by using an ARTemplate?
         if not sets and self.getTemplate():
             adv = self.getTemplate().getAnalysisServiceSettings(uid)
-            if adv.get('hidden'):
-                sets = [adv]
+            sets = [adv] if 'hidden' in adv else []
 
         # Created by using an AR Profile?
         if not sets and self.getProfile():
             adv = self.getProfile().getAnalysisServiceSettings(uid)
-            if adv.get('hidden'):
-                sets = [adv]
+            sets = [adv] if 'hidden' in adv else []
 
         return sets[0] if sets else {'uid': uid}
 

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -789,6 +789,18 @@ schema = BikaSchema.copy() + Schema((
                                 "type here."),
                         ),
     ),
+    BooleanField('Hidden',
+                 schemata="Analysis",
+                 default=False,
+                 widget=BooleanWidget(
+                     label = _("Hidden"),
+                     description = _(
+                        "If enabled, this analysis and its results "
+                        "will not be displayed by default in reports. "
+                        "This setting can be overrided in Analysis "
+                        "Profile and/or Analysis Request"),
+                 ),
+    ),
 ))
 
 schema['id'].widget.visible = False
@@ -1106,7 +1118,7 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         the method will return the exponential precision value set in
         the Schema. Otherwise, will calculate the precision value
         according to the Uncertainty and the result.
-        
+
         If Calculate Precision from the Uncertainty is set but no
         result provided neither uncertainty values are set, returns the
         fixed exponential precision.

--- a/bika/lims/content/artemplate.py
+++ b/bika/lims/content/artemplate.py
@@ -222,4 +222,8 @@ class ARTemplate(BaseContent):
                 if s.get('uid','') == uid]
         return sets[0] if sets else {'uid': uid}
 
+    def isAnalysisServiceHidden(self, uid):
+        sets = self.getAnalysisServiceSettings(uid)
+        return sets.get('hidden', False)
+
 registerType(ARTemplate, PROJECTNAME)

--- a/bika/lims/content/artemplate.py
+++ b/bika/lims/content/artemplate.py
@@ -171,6 +171,16 @@ schema = BikaSchema.copy() + Schema((
             description=_("Select analyses to include in this template"),
         )
     ),
+    # Custom settings for the assigned analysis services
+    # https://jira.bikalabs.com/browse/LIMS-1324
+    # Fields:
+    #   - uid: Analysis Service UID
+    #   - hidden: True/False. Hide/Display in results reports
+    RecordsField('AnalysisServicesSettings',
+         required=0,
+         subfields=('uid', 'hidden',),
+         widget=ComputedWidget(visible=False),
+    ),
 ),
 )
 
@@ -205,6 +215,11 @@ class ARTemplate(BaseContent):
         return DisplayList(items)
 
     def getClientUID(self):
-        return self.aq_parent.UID();
+        return self.aq_parent.UID()
+
+    def getAnalysisServiceSettings(self, uid):
+        sets = [s for s in self.getAnalysisServicesSettings() \
+                if s.get('uid','') == uid]
+        return sets[0] if sets else {'uid': uid}
 
 registerType(ARTemplate, PROJECTNAME)

--- a/bika/lims/content/artemplate.py
+++ b/bika/lims/content/artemplate.py
@@ -218,12 +218,35 @@ class ARTemplate(BaseContent):
         return self.aq_parent.UID()
 
     def getAnalysisServiceSettings(self, uid):
+        """ Returns a dictionary with the settings for the analysis
+            service that match with the uid provided.
+            If there are no settings for the analysis service and
+            template, returns a dictionary with the key 'uid'
+        """
         sets = [s for s in self.getAnalysisServicesSettings() \
                 if s.get('uid','') == uid]
         return sets[0] if sets else {'uid': uid}
 
     def isAnalysisServiceHidden(self, uid):
+        """ Checks if the analysis service that match with the uid
+            provided must be hidden in results.
+            If no hidden assignment has been set for the analysis in
+            this template, returns the visibility set to the analysis
+            itself.
+            Raise a TypeError if the uid is empty or None
+            Raise a ValueError if there is no hidden assignment in this
+                template or no analysis service found for this uid.
+        """
+        if not uid:
+            raise TypeError('None type or empty uid')
         sets = self.getAnalysisServiceSettings(uid)
+        if 'hidden' not in sets:
+            uc = getToolByName(self, 'uid_catalog')
+            serv = uc(UID=uid)
+            if serv and len(serv) == 1:
+                return serv[0].getObject().getRawHidden()
+            else:
+                raise ValueError('%s is not valid' % uid)
         return sets.get('hidden', False)
 
 registerType(ARTemplate, PROJECTNAME)

--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -43,111 +43,171 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.artemplate = artemp['artemplate-2']
 
     def tearDown(self):
-        self.services[1].setHidden(False)
-        self.services[2].setHidden(False)
+        # Restore
+        for s in self.services:
+            s.setHidden(False)
+
+        self.analysisprofile.setAnalysisServicesSettings([])
+        self.artemplate.setAnalysisServicesSettings([])
+
         logout()
         super(TestHiddenAnalyses, self).tearDown()
 
-    def test_set_hidden_field(self):
-        # analyses
+    def test_service_hidden_service(self):
+        service = self.services[1]
+        uid = service.UID()
+        self.assertFalse(service.getHidden())
+        self.assertFalse(service.Schema().getField('Hidden').get(service))
+
+        service.setHidden(False)
+        self.assertFalse(service.getHidden())
+        self.assertFalse(service.Schema().getField('Hidden').get(service))
+        service.setHidden(True)
+        self.assertTrue(service.getHidden())
+        self.assertTrue(service.Schema().getField('Hidden').get(service))
+
+        # Restore
+        service.setHidden(False)
+
+    def test_service_hidden_profile(self):
+        # Profile
+        # For Calcium (unset)
+        uid = self.services[0].UID();
         self.assertFalse(self.services[0].getHidden())
-        self.assertFalse(self.services[0].Schema().getField('Hidden').get(self.services[0]))
-        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(self.services[0].UID()))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[0].UID()))
-        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(self.services[0].UID()))
-        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[0].UID()))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
 
+        # For Copper (False)
+        uid = self.services[1].UID()
         self.assertFalse(self.services[1].getHidden())
-        self.assertFalse(self.services[1].Schema().getField('Hidden').get(self.services[1]))
-        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
-        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
 
-        self.assertTrue(self.services[2].getHidden(), True)
-        self.assertTrue(self.services[2].Schema().getField('Hidden').get(self.services[2]))
-        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[2].UID()))
-        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
-
-        self.services[1].setHidden(True)
-        self.assertTrue(self.services[1].getHidden(), True)
-        self.assertTrue(self.services[1].Schema().getField('Hidden').get(self.services[1]))
-        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
-        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
-
-        self.services[2].setHidden(False)
-        self.assertFalse(self.services[2].getHidden())
-        self.assertFalse(self.services[2].Schema().getField('Hidden').get(self.services[2]))
-        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[2].UID()))
-        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
-
-        self.services[1].setHidden(False)
-        self.assertFalse(self.services[1].getHidden())
-        self.assertFalse(self.services[1].Schema().getField('Hidden').get(self.services[1]))
-        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
-        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
-        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
-
-        self.services[2].setHidden(True)
+        # For Iron (True)
+        uid = self.services[2].UID()
         self.assertTrue(self.services[2].getHidden())
-        self.assertTrue(self.services[2].Schema().getField('Hidden').get(self.services[2]))
-        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
-        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
-        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
-
-        # profile
-        uid = self.services[0].UID()
-        sets = [{'uid': uid}]
-        self.analysisprofile.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
-        sets[0]['hidden'] = False
-        self.analysisprofile.setAnalysisServicesSettings(sets)
-        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(uid).get('hidden'))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
-        sets[0]['hidden'] = True
-        self.analysisprofile.setAnalysisServicesSettings(sets)
-        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(uid).get('hidden'))
         self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
-        sets = []
-        self.analysisprofile.setAnalysisServicesSettings(sets)
         self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
-        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
 
-        # template
-        uid = self.services[0].UID()
+        # Modify visibility for Calcium in profile
+        uid = self.services[0].UID();
+        sets = [{'uid': uid}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': False}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+
+        sets = [{'uid': uid, 'hidden': True}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+
+        # Modify visibility for Cooper in profile
+        uid = self.services[1].UID();
+        sets = [{'uid': uid}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': False}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': True}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+
+        # Modify visibility for Iron in profile
+        uid = self.services[2].UID();
+        sets = [{'uid': uid}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': False}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': True}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+
+        # Restore
+        self.analysisprofile.setAnalysisServicesSettings([])
+
+    def test_service_hidden_artemplate(self):
+        # Template
+        # For Calcium (unset)
+        uid = self.services[0].UID();
+        self.assertFalse(self.services[0].getHidden())
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        # For Copper (False)
+        uid = self.services[1].UID()
+        self.assertFalse(self.services[1].getHidden())
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        # For Iron (True)
+        uid = self.services[2].UID()
+        self.assertTrue(self.services[2].getHidden())
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        # Modify visibility for Calcium in template
+        uid = self.services[0].UID();
         sets = [{'uid': uid}]
         self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
-        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
-        sets[0]['hidden'] = False
+        sets = [{'uid': uid, 'hidden': False}]
         self.artemplate.setAnalysisServicesSettings(sets)
-        self.assertFalse(self.artemplate.getAnalysisServiceSettings(uid).get('hidden'))
         self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
-        sets[0]['hidden'] = True
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        sets = [{'uid': uid, 'hidden': True}]
         self.artemplate.setAnalysisServicesSettings(sets)
-        self.assertTrue(self.artemplate.getAnalysisServiceSettings(uid).get('hidden'))
         self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
-        sets = []
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        # Modify visibility for Cooper in template
+        uid = self.services[1].UID();
+        sets = [{'uid': uid}]
         self.artemplate.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
         self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': False}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': True}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
 
-    def test_ar_hidden_analyses(self):
-        # Calcium - Hidden not set
-        # Copper  - Hidden set to False
-        self.services[1].setHidden(False)
-        # Iron    - Hidden set to True
-        self.services[2].setHidden(True)
+        # Modify visibility for Iron in template
+        uid = self.services[2].UID();
+        sets = [{'uid': uid}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': False}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': True}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
 
+        # Restore
+        self.artemplate.setAnalysisServicesSettings([])
+
+    def test_service_hidden_analysisrequest(self):
         # Input results
         # Client:       Happy Hills
         # SampleType:   Apple Pulp
@@ -166,150 +226,89 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.assertFalse(ar.isAnalysisServiceHidden(services[0]))
         self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
         self.assertFalse(ar.isAnalysisServiceHidden(services[1]))
-        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        self.assertFalse(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
         self.assertTrue(ar.isAnalysisServiceHidden(services[2]))
-        uid = services[0]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+
+        # For Calcium (unset)
+        uid = self.services[0].UID()
+        self.assertFalse(self.services[0].getHidden())
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+
+        # For Copper (False)
+        uid = self.services[1].UID()
+        self.assertFalse(self.services[1].getHidden())
         self.assertFalse(ar.isAnalysisServiceHidden(uid))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[1]
+
+        # For Iron (True)
+        uid = self.services[2].UID()
+        self.assertTrue(self.services[2].getHidden())
+        self.assertTrue(ar.isAnalysisServiceHidden(uid))
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+
+        # Modify visibility for Calcium in AR
+        uid = self.services[0].UID();
         sets = [{'uid': uid}]
         ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        sets[0]['hidden'] = False
+        sets = [{'uid': uid, 'hidden': False}]
         ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets = [{'uid': uid, 'hidden': True}]
         ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[2]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        self.assertTrue(ar.isAnalysisServiceHidden(uid))
+        self.assertTrue('hidden' in ar.getAnalysisServiceSettings(uid))
+        ar.setAnalysisServicesSettings([])
 
         # AR with profile with no changes
         values['Profile'] = self.analysisprofile.UID()
         ar = create_analysisrequest(client, request, values, services)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
         self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
-        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
-        uid = services[0]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        uid = self.services[0].UID()
+        self.assertFalse(self.services[0].getHidden())
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
+        uid = self.services[1].UID()
+        self.assertFalse(self.services[1].getHidden())
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[1]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[2]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
+        uid = self.services[2].UID()
+        self.assertTrue(self.services[2].getHidden())
+        self.assertTrue(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
 
-        # AR with profile and template, without changes
-        values['Profile'] = self.analysisprofile.UID()
-        values['Template'] = self.artemplate.UID()
+        # AR with template with no changes
+        values['Template'] = self.artemplate
+        del values['Profile']
         ar = create_analysisrequest(client, request, values, services)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
         self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
-        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
-        uid = services[0]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        uid = self.services[0].UID()
+        self.assertFalse(self.services[0].getHidden())
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
+        uid = self.services[1].UID()
+        self.assertFalse(self.services[1].getHidden())
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[1]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
-        uid = services[2]
-        sets = [{'uid': uid}]
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = False
-        ar.setAnalysisServicesSettings(sets)
-        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets[0]['hidden'] = True
-        ar.setAnalysisServicesSettings(sets)
-        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
-        sets = []
-        ar.setAnalysisServicesSettings(sets)
+        uid = self.services[2].UID()
+        self.assertTrue(self.services[2].getHidden())
+        self.assertTrue(ar.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
 
         # AR with profile, with changes
         values['Profile'] = self.analysisprofile.UID()
         del values['Template']
-        matrix = [[0, 1,-1],  # AS = Not set
-                  [0, 1, 0],  # AS = False
-                  [0, 1, 1]]
-        uid = services[0]
-        for i in matrix:
+        matrix = [[2, 1,-2],  # AS = Not set
+                  [2, 1,-2],  # AS = False
+                  [2, 1,-1]]
+        for i in range(len(matrix)):
             sets = {'uid': services[i]}
             opts = [0, 1, 2]
             for j in opts:
@@ -319,25 +318,28 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
                     sets['hidden'] = True
                 else:
                     del sets['hidden']
-                self.analysisprofile.setAnalysesSettings(sets)
+                self.analysisprofile.setAnalysisServicesSettings(sets)
                 ar = create_analysisrequest(client, request, values, services)
+                res = matrix[i][j]
+                if res < 0:
+                    self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[i]))
+                else:
+                    self.assertTrue('hidden' in ar.getAnalysisServiceSettings(services[i]))
+                if abs(res) == 1:
+                    self.assertTrue(ar.isAnalysisServiceHidden(services[i]))
+                elif abs(res) == 2:
+                    self.assertFalse(ar.isAnalysisServiceHidden(services[i]))
 
-                res = matrix[j]
-                if res == 0:
-                    self.assertFalse(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
-                elif res == 1:
-                    self.assertTrue(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
-                elif res == -1:
-                    self.assertFalse('hidden' not in ar.getAnalysisServiceSettings(services[i]))
+        # Restore
+        self.analysisprofile.setAnalysisServicesSettings([])
 
         # AR with template, with changes
         values['Template'] = self.artemplate.UID()
         del values['Profile']
-        matrix = [[0, 1,-1],  # AS = Not set
-                  [0, 1, 0],  # AS = False
-                  [0, 1, 1]]
-        uid = services[0]
-        for i in matrix:
+        matrix = [[2, 1,-2],  # AS = Not set
+                  [2, 1,-2],  # AS = False
+                  [2, 1,-1]]
+        for i in range(len(matrix)):
             sets = {'uid': services[i]}
             opts = [0, 1, 2]
             for j in opts:
@@ -347,16 +349,20 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
                     sets['hidden'] = True
                 else:
                     del sets['hidden']
-                self.artemplate.setAnalysesSettings(sets)
+                self.artemplate.setAnalysisServicesSettings(sets)
                 ar = create_analysisrequest(client, request, values, services)
+                res = matrix[i][j]
+                if res < 0:
+                    self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[i]))
+                else:
+                    self.assertTrue('hidden' in ar.getAnalysisServiceSettings(services[i]))
+                if abs(res) == 1:
+                    self.assertTrue(ar.isAnalysisServiceHidden(services[i]))
+                elif abs(res) == 2:
+                    self.assertFalse(ar.isAnalysisServiceHidden(services[i]))
 
-                res = matrix[j]
-                if res == 0:
-                    self.assertFalse(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
-                elif res == 1:
-                    self.assertTrue(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
-                elif res == -1:
-                    self.assertFalse('hidden' not in ar.getAnalysisServiceSettings(services[i]))
+        # Restore
+        self.artemplate.setAnalysisServicesSettings([])
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -1,0 +1,365 @@
+from bika.lims.content.analysis import Analysis
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.workflow import doActionFor
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError: # Python 2.7
+    import unittest
+
+
+class TestHiddenAnalyses(BikaFunctionalTestCase):
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestHiddenAnalyses, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+        servs = self.portal.bika_setup.bika_analysisservices
+
+        # analysis-service-3: Calcium (Ca)
+        # analysis-service-6: Cooper (Cu)
+        # analysis-service-7: Iron (Fe)
+        self.services = [servs['analysisservice-3'],
+                         servs['analysisservice-6'],
+                         servs['analysisservice-7']]
+
+        # Calcium - Hidden not set
+        # Copper  - Hidden set to False
+        self.services[1].setHidden(False)
+        # Iron    - Hidden set to True
+        self.services[2].setHidden(True)
+
+        profs = self.portal.bika_setup.bika_analysisprofiles
+        # analysisprofile-1: Trace Metals
+        self.analysisprofile = profs['analysisprofile-1']
+
+        artemp = self.portal.bika_setup.bika_artemplates
+        # artemplate-2: Bruma Metals
+        self.artemplate = artemp['artemplate-2']
+
+    def tearDown(self):
+        self.services[1].setHidden(False)
+        self.services[2].setHidden(False)
+        logout()
+        super(TestHiddenAnalyses, self).tearDown()
+
+    def test_set_hidden_field(self):
+        # analyses
+        self.assertFalse(self.services[0].getHidden())
+        self.assertFalse(self.services[0].Schema().getField('Hidden').get(self.services[0]))
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(self.services[0].UID()))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[0].UID()))
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(self.services[0].UID()))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[0].UID()))
+
+        self.assertFalse(self.services[1].getHidden())
+        self.assertFalse(self.services[1].Schema().getField('Hidden').get(self.services[1]))
+        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
+        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
+
+        self.assertTrue(self.services[2].getHidden(), True)
+        self.assertTrue(self.services[2].Schema().getField('Hidden').get(self.services[2]))
+        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[2].UID()))
+        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
+
+        self.services[1].setHidden(True)
+        self.assertTrue(self.services[1].getHidden(), True)
+        self.assertTrue(self.services[1].Schema().getField('Hidden').get(self.services[1]))
+        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
+        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
+
+        self.services[2].setHidden(False)
+        self.assertFalse(self.services[2].getHidden())
+        self.assertFalse(self.services[2].Schema().getField('Hidden').get(self.services[2]))
+        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[2].UID()))
+        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
+
+        self.services[1].setHidden(False)
+        self.assertFalse(self.services[1].getHidden())
+        self.assertFalse(self.services[1].Schema().getField('Hidden').get(self.services[1]))
+        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
+        self.assertFalse(self.artemplate.getAnalysisServiceSettings(self.services[1].UID()).get('hidden'))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(self.services[1].UID()))
+
+        self.services[2].setHidden(True)
+        self.assertTrue(self.services[2].getHidden())
+        self.assertTrue(self.services[2].Schema().getField('Hidden').get(self.services[2]))
+        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(self.services[1].UID()))
+        self.assertTrue(self.artemplate.getAnalysisServiceSettings(self.services[2].UID()).get('hidden'))
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(self.services[2].UID()))
+
+        # profile
+        uid = self.services[0].UID()
+        sets = [{'uid': uid}]
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        sets[0]['hidden'] = False
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.analysisprofile.getAnalysisServiceSettings(uid).get('hidden'))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+        sets[0]['hidden'] = True
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.analysisprofile.getAnalysisServiceSettings(uid).get('hidden'))
+        self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
+        sets = []
+        self.analysisprofile.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
+        self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
+
+        # template
+        uid = self.services[0].UID()
+        sets = [{'uid': uid}]
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        sets[0]['hidden'] = False
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse(self.artemplate.getAnalysisServiceSettings(uid).get('hidden'))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+        sets[0]['hidden'] = True
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertTrue(self.artemplate.getAnalysisServiceSettings(uid).get('hidden'))
+        self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))
+        sets = []
+        self.artemplate.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
+        self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
+
+    def test_ar_hidden_analyses(self):
+        # Calcium - Hidden not set
+        # Copper  - Hidden set to False
+        self.services[1].setHidden(False)
+        # Iron    - Hidden set to True
+        self.services[2].setHidden(True)
+
+        # Input results
+        # Client:       Happy Hills
+        # SampleType:   Apple Pulp
+        # Contact:      Rita Mohale
+        # Analyses:     [Calcium, Copper, Iron]
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        request = {}
+        services = [s.UID() for s in self.services]
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        ar = create_analysisrequest(client, request, values, services)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
+        self.assertFalse(ar.isAnalysisServiceHidden(services[0]))
+        self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
+        self.assertFalse(ar.isAnalysisServiceHidden(services[1]))
+        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        self.assertTrue(ar.isAnalysisServiceHidden(services[2]))
+        uid = services[0]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        self.assertFalse(ar.isAnalysisServiceHidden(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[1]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[2]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+
+        # AR with profile with no changes
+        values['Profile'] = self.analysisprofile.UID()
+        ar = create_analysisrequest(client, request, values, services)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
+        self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
+        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        uid = services[0]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[1]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[2]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+
+        # AR with profile and template, without changes
+        values['Profile'] = self.analysisprofile.UID()
+        values['Template'] = self.artemplate.UID()
+        ar = create_analysisrequest(client, request, values, services)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
+        self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
+        self.assertTrue(ar.getAnalysisServiceSettings(services[2]).get('hidden'))
+        uid = services[0]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[1]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+        uid = services[2]
+        sets = [{'uid': uid}]
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = False
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets[0]['hidden'] = True
+        ar.setAnalysisServicesSettings(sets)
+        self.assertTrue(ar.getAnalysisServiceSettings(uid).get('hidden'))
+        sets = []
+        ar.setAnalysisServicesSettings(sets)
+        self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
+
+        # AR with profile, with changes
+        values['Profile'] = self.analysisprofile.UID()
+        del values['Template']
+        matrix = [[0, 1,-1],  # AS = Not set
+                  [0, 1, 0],  # AS = False
+                  [0, 1, 1]]
+        uid = services[0]
+        for i in matrix:
+            sets = {'uid': services[i]}
+            opts = [0, 1, 2]
+            for j in opts:
+                if j == 0:
+                    sets['hidden'] = False
+                elif j == 1:
+                    sets['hidden'] = True
+                else:
+                    del sets['hidden']
+                self.analysisprofile.setAnalysesSettings(sets)
+                ar = create_analysisrequest(client, request, values, services)
+
+                res = matrix[j]
+                if res == 0:
+                    self.assertFalse(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
+                elif res == 1:
+                    self.assertTrue(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
+                elif res == -1:
+                    self.assertFalse('hidden' not in ar.getAnalysisServiceSettings(services[i]))
+
+        # AR with template, with changes
+        values['Template'] = self.artemplate.UID()
+        del values['Profile']
+        matrix = [[0, 1,-1],  # AS = Not set
+                  [0, 1, 0],  # AS = False
+                  [0, 1, 1]]
+        uid = services[0]
+        for i in matrix:
+            sets = {'uid': services[i]}
+            opts = [0, 1, 2]
+            for j in opts:
+                if j == 0:
+                    sets['hidden'] = False
+                elif j == 1:
+                    sets['hidden'] = True
+                else:
+                    del sets['hidden']
+                self.artemplate.setAnalysesSettings(sets)
+                ar = create_analysisrequest(client, request, values, services)
+
+                res = matrix[j]
+                if res == 0:
+                    self.assertFalse(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
+                elif res == 1:
+                    self.assertTrue(ar.getAnalysisServiceSettings(services[i]).get('hidden'))
+                elif res == -1:
+                    self.assertFalse('hidden' not in ar.getAnalysisServiceSettings(services[i]))
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestHiddenAnalyses))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -70,6 +70,8 @@ def create_analysisrequest(
 
     if not secondary:
         # Create sample partitions
+        if not partitions:
+            partitions = [{'services':analyses}]
         for n, partition in enumerate(partitions):
             # Calculate partition id
             partition_prefix = sample.getId() + "-P"

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.8 (unreleased)
 ------------------
 
+LIMS-1324: Allow to hide analyses in results reports
 LIMS-1745: Retracted analyses in duplicates
 LIMS-1629: Pdf reports should split analysis results in different pages according to the lab department
 Some new ID Generator's features, as the possibility of select the separator type


### PR DESCRIPTION
Added show/hide capabilities for Analyses:
- New checkbox field 'Hidden' in Analysis Service view
- New column in Analyses view from AR Profile. A checkbox field 'Hidden'
- New column in Analyses view from AR Template. A checkbox field 'Hidden'
- New column in Manage Analyses from AR View. A checkbox field 'Hidden'
- New option 'Show/Hide analyses' in reports
- By default, the 'hidden' analyses will not be displayed in results reports. 
- 'Hidden' field value overriding (if set in AR Profile, overrides the value set at AS level and so on).

```
jordi@darwin:~/dev/labsanmartin/bikalims/zinstance$ bin/test -s bika.lims -t TestHiddenAnalyses
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.156 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.182 seconds.
  Set up bika.lims.testing.BikaTestLayer in 44.855 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                
  Ran 4 tests with 0 failures and 0 errors in 13.469 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.013 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.053 seconds.
  Tear down plone.testing.z2.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.003 seconds.
```