### PR TITLE
LIMS-1748 Fixed error in adding supply order

### DIFF
--- a/bika/lims/content/labproduct.py
+++ b/bika/lims/content/labproduct.py
@@ -27,6 +27,7 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
     FixedPointField('Price',
+        required=1,
         widget = DecimalWidget(
             label=_("Price excluding VAT"),
         )

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.8 (unreleased)
 ------------------
 
+LIMS-1748: Error in adding supply order when a product has no price
 LIMS-1745: Retracted analyses in duplicates
 LIMS-1629: Pdf reports should split analysis results in different pages according to the lab department
 Some new ID Generator's features, as the possibility of select the separator type


### PR DESCRIPTION
The error occurs because price field for product is not mandatory and a product with no price raises error when adding supply order.

After discussion with xispa, I have made the price of Products mandatory. Refer the related pull request [#1488](https://github.com/bikalabs/Bika-LIMS/pull/1488).