### PR TITLE
LIMS-1741 Fixed overlay when saving supply order

### DIFF
--- a/bika/lims/browser/templates/supplyorder_edit.pt
+++ b/bika/lims/browser/templates/supplyorder_edit.pt
@@ -21,7 +21,7 @@
 		</metal:title>
 
 		<metal:core fill-slot="content-core">
-			<form id="supplyorder_edit" name="edit" method="post" action="" tal:define="errors python:{}">
+			<form id="supplyorder_edit" method="post" action="" tal:define="errors python:{}">
 				<table class="invoice-header">
 					<tbody>
 						<tal:field content="structure python:view.field(field=view.orderDate)" />

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.8 (unreleased)
 ------------------
 
+LIMS-1741: Fixed unwanted overlay when trying to save supply order
 LIMS-1748: Error in adding supply order when a product has no price
 LIMS-1745: Retracted analyses in duplicates
 LIMS-1629: Pdf reports should split analysis results in different pages according to the lab department


### PR DESCRIPTION
The unwanted overlay pops up because the form has `name="edit"`. I traced back where the overlay came from and it is `plone.app.discussion.javascript/comments.js`. It added prepOverlay to all forms with `name="edit"` for some unwanted reason.

Removing `name="edit"` not only fixed the issue, but also gave no other errors in the supply order workflow.