### PR TITLE
LIMS-1700 Lower and Upper Detection Limits (LDL/UDL). Allow manual input

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -608,13 +608,19 @@ class AnalysesView(BikaListingView):
                     isudl = obj.isAboveUpperDetectionLimit()
                     dlval=''
                     if isldl or isudl:
-                        ldl = '<' if isldl else '>'
+                        dlval = '<' if isldl else '>'
                     item['allow_edit'].append('DetectionLimit')
                     item['DetectionLimit'] = dlval
                     choices=[{'ResultValue': '<', 'ResultText': '<'},
                              {'ResultValue': '>', 'ResultText': '>'}]
                     item['choices']['DetectionLimit'] = choices
                     self.columns['DetectionLimit']['toggle'] = True
+                    srv = obj.getService()
+                    defdls = {'min':srv.getLowerDetectionLimit(),
+                              'max':srv.getUpperDetectionLimit()}
+                    defin = '<input type="hidden" id="DefaultDLS.%s" value=\'%s\'/>'
+                    defin = defin % (obj.UID(), json.dumps(defdls))
+                    item['after']['DetectionLimit'] = defin
 
             else:
                 items[i]['Specification'] = ""

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -602,6 +602,7 @@ class AnalysesView(BikaListingView):
                 # LIMS-1700. Allow manual input of Detection Limits
                 # https://jira.bikalabs.com/browse/LIMS-1700
                 if can_edit_analysis and \
+                    hasattr(obj, 'getDetectionLimitOperand') and \
                     hasattr(service, 'getAllowManualDetectionLimit') and \
                     service.getAllowManualDetectionLimit() == True:
                     isldl = obj.isBelowLowerDetectionLimit()

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -77,6 +77,10 @@ class AnalysesView(BikaListingView):
             'state_title': {
                 'title': _('Status'),
                 'sortable': False},
+            'DetectionLimit': {
+                'title': _('DL'),
+                'sortable': False,
+                'toggle': False},
             'Result': {
                 'title': _('Result'),
                 'input_width': '6',
@@ -115,6 +119,7 @@ class AnalysesView(BikaListingView):
              'contentFilter': {},
              'columns': ['Service',
                          'Partition',
+                         'DetectionLimit',
                          'Result',
                          'Specification',
                          'Method',
@@ -341,6 +346,7 @@ class AnalysesView(BikaListingView):
             items[i]['interim_fields'] = interim_fields
             items[i]['Remarks'] = obj.getRemarks()
             items[i]['Uncertainty'] = ''
+            items[i]['DetectionLimit'] = ''
             items[i]['retested'] = obj.getRetested()
             items[i]['class']['retested'] = 'center'
             items[i]['result_captured'] = self.ulocalized_time(
@@ -578,6 +584,8 @@ class AnalysesView(BikaListingView):
                 dmk = self.context.bika_setup.getResultsDecimalMark()
                 items[i]['formatted_result'] = obj.getFormattedResult(sciformat=int(scinot),decimalmark=dmk)
 
+                # LIMS-1379 Allow manual uncertainty value input
+                # https://jira.bikalabs.com/browse/LIMS-1379
                 fu = format_uncertainty(obj, result, decimalmark=dmk, sciformat=int(scinot))
                 fu = fu if fu else ''
                 if can_edit_analysis and service.getAllowManualUncertainty() == True:
@@ -590,6 +598,23 @@ class AnalysesView(BikaListingView):
                     items[i]['Uncertainty'] = fu
                     items[i]['before']['Uncertainty'] = '&plusmn;&nbsp;';
                     items[i]['after']['Uncertainty'] = '<em class="discreet" style="white-space:nowrap;"> %s</em>' % items[i]['Unit'];
+
+                # LIMS-1700. Allow manual input of Detection Limits
+                # https://jira.bikalabs.com/browse/LIMS-1700
+                if can_edit_analysis and \
+                    hasattr(service, 'getAllowManualDetectionLimit') and \
+                    service.getAllowManualDetectionLimit() == True:
+                    isldl = obj.isBelowLowerDetectionLimit()
+                    isudl = obj.isAboveUpperDetectionLimit()
+                    dlval=''
+                    if isldl or isudl:
+                        ldl = '<' if isldl else '>'
+                    item['allow_edit'].append('DetectionLimit')
+                    item['DetectionLimit'] = dlval
+                    choices=[{'ResultValue': '<', 'ResultText': '<'},
+                             {'ResultValue': '>', 'ResultText': '>'}]
+                    item['choices']['DetectionLimit'] = choices
+                    self.columns['DetectionLimit']['toggle'] = True
 
             else:
                 items[i]['Specification'] = ""

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -364,19 +364,8 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
                 analysis.setUncertainty(uncertainties[uid])
 
             # Need to save the detection limit?
-            if uid in dlimits and analysis_active and dlimits[uid]:
-                dlimit = dlimits[uid]
-                rawres = analysis.getResult()
-                try:
-                    rawres = float(rawres)
-                except:
-                    rawres = None
-                if dlimit == '<':
-                    rawres = rawres if rawres else analysis.getLowerDetectionLimit()
-                    analysis.setLowerDetectionLimit(str(rawres))
-                elif dlimit == '>':
-                    rawres = rawres if rawres else analysis.getUpperDetectionLimit()
-                    analysis.setUpperDetectionLimit(str(rawres))
+            if analysis_active and uid in dlimits and dlimits[uid]:
+                analysis.setDetectionLimitOperand(dlimits[uid])
 
             if uid not in results or not results[uid]:
                 continue

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -318,6 +318,7 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
         instruments = self.request.form.get('Instrument', [{}])[0]
         analysts = self.request.form.get('Analyst', [{}])[0]
         uncertainties = self.request.form.get('Uncertainty', [{}])[0]
+        dlimits = self.request.form.get('DetectionLimit', [{}])[0]
         # discover which items may be submitted
         submissable = []
         for uid, analysis in selected_analyses.items():
@@ -361,6 +362,21 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
             # Need to save the uncertainty?
             if uid in uncertainties and analysis_active:
                 analysis.setUncertainty(uncertainties[uid])
+
+            # Need to save the detection limit?
+            if uid in dlimits and analysis_active and dlimits[uid]:
+                dlimit = dlimits[uid]
+                rawres = analysis.getResult()
+                try:
+                    rawres = float(rawres)
+                except:
+                    rawres = None
+                if dlimit == '<':
+                    rawres = rawres if rawres else analysis.getLowerDetectionLimit()
+                    analysis.setLowerDetectionLimit(str(rawres))
+                elif dlimit == '>':
+                    rawres = rawres if rawres else analysis.getUpperDetectionLimit()
+                    analysis.setUpperDetectionLimit(str(rawres))
 
             if uid not in results or not results[uid]:
                 continue

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -240,6 +240,8 @@ function WorksheetManageResultsView() {
         loadWideInterimsEventHandlers();
 
         loadRemarksEventHandlers();
+
+        loadDetectionLimitsEventHandlers();
     }
 
     function portalMessage(message) {
@@ -267,6 +269,21 @@ function WorksheetManageResultsView() {
             }
         });
         $("a.add-remark").click();
+    }
+
+    function loadDetectionLimitsEventHandlers() {
+        $('select[name^="DetectionLimit."]').change(function() {
+            var defdls = $(this).closest('td').find('input[id^="DefaultDLS."]').first().val();
+            var resfld = $(this).closest('tr').find('input[name^="Result."]')[0];
+            defdls = $.parseJSON(defdls);
+            if ($(this).val() == '<') {
+                $(resfld).val(defdls['min']);
+            } else if ($(this).val() == '>') {
+                $(resfld).val(defdls['max']);
+            } else {
+                $(resfld).val('');
+            }
+        });
     }
 
     function loadWideInterimsEventHandlers() {

--- a/bika/lims/browser/worksheet.py
+++ b/bika/lims/browser/worksheet.py
@@ -397,6 +397,10 @@ class WorksheetAnalysesView(AnalysesView):
             'Service': {'title': _('Analysis')},
             'getPriority': {'title': _('Priority')},
             'Method': {'title': _('Method')},
+            'DetectionLimit': {
+                'title': _('DL'),
+                'sortable': False,
+                'toggle': False},
             'Result': {'title': _('Result'),
                        'input_width': '6',
                        'input_class': 'ajax_calculate numeric',
@@ -423,6 +427,7 @@ class WorksheetAnalysesView(AnalysesView):
                         'Priority',
                         'Method',
                         'Instrument',
+                        'DetectionLimit',
                         'Result',
                         'Uncertainty',
                         'DueDate',

--- a/bika/lims/browser/worksheet.py
+++ b/bika/lims/browser/worksheet.py
@@ -128,6 +128,7 @@ class WorksheetWorkflowAction(WorkflowAction):
         instruments = form.get('Instrument', [{}])[0]
         analysts = self.request.form.get('Analyst', [{}])[0]
         uncertainties = self.request.form.get('Uncertainty', [{}])[0]
+        dlimits = self.request.form.get('DetectionLimit', [{}])[0]
         selected = WorkflowAction._get_selected_items(self)
         workflow = getToolByName(self.context, 'portal_workflow')
         rc = getToolByName(self.context, REFERENCE_CATALOG)
@@ -199,6 +200,10 @@ class WorksheetWorkflowAction(WorkflowAction):
             # Need to save the uncertainty?
             if uid in uncertainties and analysis_active:
                 analysis.setUncertainty(uncertainties[uid])
+
+            # Need to save the detection limit?
+            if analysis_active and uid in dlimits and dlimits[uid]:
+                analysis.setDetectionLimitOperand(dlimits[uid])
 
             # Need to save results?
             if uid in results and results[uid] and allow_edit \

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -311,6 +311,39 @@ class Analysis(BaseContent):
         except:
             return 0
 
+    def isBelowLowerDetectionLimit(self):
+        """ Returns True if the result is below the Lower Detection
+            Limit or if Lower Detection Limit has been manually set
+        """
+        result = self.getResult()
+        if result and str(result).strip().startswith('<'):
+            return True
+        elif result:
+            ldl = self.getLowerDetectionLimit()
+            try:
+                result = float(result)
+                return result < ldl
+            except:
+                pass
+        return False
+
+    def isAboveUpperDetectionLimit(self):
+        """ Returns True if the result is above the Upper Detection
+            Limit or if Upper Detection Limit has been manually set
+        """
+        result = self.getResult()
+        if result and str(result).strip().startswith('>'):
+            return True
+        elif result:
+            udl = self.getUpperDetectionLimit()
+            try:
+                result = float(result)
+                return result > udl
+            except:
+                pass
+        return False
+
+
     def getDetectionLimits(self):
         """ Returns a two-value array with the limits of detection
             (LDL and UDL) that applies to this analysis in particular.

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -368,7 +368,7 @@ class Analysis(BaseContent):
             manual input of detection limits, returns the value set by
             default in the Analysis Service
         """
-        return [getLowerDetectionLimit(), getUpperDetectionLimit()]
+        return [self.getLowerDetectionLimit(), self.getUpperDetectionLimit()]
 
     def getDependents(self):
         """ Return a list of analyses who depend on us

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -667,7 +667,9 @@ class Analysis(BaseContent):
         2. If the result is not floatable, return it without being formatted
         3. If the analysis specs has hidemin or hidemax enabled and the
            result is out of range, render result as '<min' or '>max'
-        4. Otherwise, render numerical value
+        4. If the result is below Lower Detection Limit, show '<LDL'
+        5. If the result is above Upper Detecion Limit, show '>UDL'
+        6. Otherwise, render numerical value
         specs param is optional. A dictionary as follows:
             {'min': <min_val>,
              'max': <max_val>,
@@ -722,6 +724,16 @@ class Analysis(BaseContent):
         # 3.2. If result is above max and hidemax enabled, return '>max'
         if abovemax:
             return formatDecimalMark('> %s' % hidemax, decimalmark)
+
+        # Below Lower Detection Limit (LDL)?
+        ldl = self.getLowerDetectionLimit()
+        if result < ldl
+            return formatDecimalMark('< %s' % ldl, decimalmark)
+
+        # Above Upper Detection Limit (UDL)?
+        udl = self.getUpperDetectionLimit()
+        if result > udl
+            return formatDecimalMark('> %s' % udl, decimalmark)
 
         # Render numerical values
         return formatDecimalMark(format_numeric_result(self, result, sciformat=sciformat), decimalmark=decimalmark)

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -187,12 +187,12 @@ schema = BikaSchema.copy() + Schema((
             label = _("Uncertainty"),
         ),
     ),
-    FixedPointField('LowerLimitOfDetection',
+    FixedPointField('LowerDetectionLimit',
         widget=DecimalWidget(
             label = _("Lower Limit of Detection (LDL)"),
         ),
     ),
-    FixedPointField('UpperLimitOfDetection',
+    FixedPointField('UpperDetectionLimit',
         widget=DecimalWidget(
             label = _("Upper Limit of Detection (UDL)"),
         ),
@@ -289,7 +289,11 @@ class Analysis(BaseContent):
         serv = self.getService()
         dl = self.Schema().getField('LowerDetectionLimit').get(self)
         am = serv.getAllowManualDetectionLimit()
-        return dl if (dl and am) else serv.getLowerDetectionLimit()
+        dl = dl if (dl and am) else serv.getLowerDetectionLimit()
+        try:
+            return float(dl)
+        except:
+            return 0
 
     def getUpperDetectionLimit(self):
         """ Returns the Upper Detection Limit (UDL) that applies to
@@ -301,7 +305,11 @@ class Analysis(BaseContent):
         serv = self.getService()
         dl = self.Schema().getField('UpperDetectionLimit').get(self)
         am = serv.getAllowManualDetectionLimit()
-        return dl if (dl and am) else serv.getUpperDetectionLimit()
+        dl = dl if (dl and am) else serv.getUpperDetectionLimit()
+        try:
+            return float(dl)
+        except:
+            return 0
 
     def getDetectionLimits(self):
         """ Returns a two-value array with the limits of detection
@@ -727,12 +735,12 @@ class Analysis(BaseContent):
 
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()
-        if result < ldl
+        if result < ldl:
             return formatDecimalMark('< %s' % ldl, decimalmark)
 
         # Above Upper Detection Limit (UDL)?
         udl = self.getUpperDetectionLimit()
-        if result > udl
+        if result > udl:
             return formatDecimalMark('> %s' % udl, decimalmark)
 
         # Render numerical values

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -1061,6 +1061,8 @@ class Analysis(BaseContent):
             ReportDryMatter=self.getReportDryMatter(),
             Analyst=self.getAnalyst(),
             Instrument=self.getInstrument(),
+            LowerDetectionLimit=str(self.getLowerDetectionLimit()),
+            UpperDetectionLimit=str(self.getUpperDetectionLimit()),
             SamplePartition=self.getSamplePartition())
         analysis.unmarkCreationFlag()
 

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -5,6 +5,7 @@
 from AccessControl import getSecurityManager
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime
+from bika.lims import logger
 from bika.lims.utils.analysis import format_numeric_result
 from plone.indexer import indexer
 from Products.ATContentTypes.content import schemata
@@ -187,16 +188,9 @@ schema = BikaSchema.copy() + Schema((
             label = _("Uncertainty"),
         ),
     ),
-    FixedPointField('LowerDetectionLimit',
-        widget=DecimalWidget(
-            label = _("Lower Limit of Detection (LDL)"),
-        ),
+    StringField('DetectionLimitOperand',
     ),
-    FixedPointField('UpperDetectionLimit',
-        widget=DecimalWidget(
-            label = _("Upper Limit of Detection (UDL)"),
-        ),
-    ),
+
 ),
 )
 
@@ -279,6 +273,18 @@ class Analysis(BaseContent):
                 return self.getDefaultUncertainty(result)
         return self.getDefaultUncertainty(result)
 
+    def setDetectionLimitOperand(self, value):
+        """ Sets the detection limit operand for this analysis, so
+            the result will be interpreted as a detection limit.
+            The value will only be set if the Service has 'Allow manual
+            detection limit' field set to True, otherwise, the detection
+            limit operand will be set to None.
+        """
+        srv = self.getService()
+        md = srv.getAllowManualDetectionLimit() if srv else False
+        val = value if (md and value in ('>', '<')) else None
+        self.Schema().getField('DetectionLimitOperand').set(self, val)
+
     def getLowerDetectionLimit(self):
         """ Returns the Lower Detection Limit (LDL) that applies to
             this analysis in particular. If no value set or the
@@ -286,14 +292,17 @@ class Analysis(BaseContent):
             limits, returns the value set by default in the Analysis
             Service
         """
-        serv = self.getService()
-        dl = self.Schema().getField('LowerDetectionLimit').get(self)
-        am = serv.getAllowManualDetectionLimit()
-        dl = dl if (dl and am) else serv.getLowerDetectionLimit()
-        try:
-            return float(dl)
-        except:
-            return 0
+        operand = self.getDetectionLimitOperand()
+        if operand and operand == '<':
+            result = self.getResult()
+            try:
+                return float(result)
+            except:
+                logger.warn("The result for the analysis %s is a lower "
+                            "detection limit, but not floatable: '%s'. "
+                            "Returnig AS's default LDL." %
+                            (self.id, result))
+        return self.getService().getLowerDetectionLimit()
 
     def getUpperDetectionLimit(self):
         """ Returns the Upper Detection Limit (UDL) that applies to
@@ -302,19 +311,25 @@ class Analysis(BaseContent):
             limits, returns the value set by default in the Analysis
             Service
         """
-        serv = self.getService()
-        dl = self.Schema().getField('UpperDetectionLimit').get(self)
-        am = serv.getAllowManualDetectionLimit()
-        dl = dl if (dl and am) else serv.getUpperDetectionLimit()
-        try:
-            return float(dl)
-        except:
-            return 0
+        operand = self.getDetectionLimitOperand()
+        if operand and operand == '>':
+            result = self.getResult()
+            try:
+                return float(result)
+            except:
+                logger.warn("The result for the analysis %s is a lower "
+                            "detection limit, but not floatable: '%s'. "
+                            "Returnig AS's default LDL." %
+                            (self.id, result))
+        return self.getService().getLowerDetectionLimit()
 
     def isBelowLowerDetectionLimit(self):
         """ Returns True if the result is below the Lower Detection
             Limit or if Lower Detection Limit has been manually set
         """
+        dl = self.getDetectionLimitOperand()
+        if dl and dl == '<':
+            return True
         result = self.getResult()
         if result and str(result).strip().startswith('<'):
             return True
@@ -331,6 +346,9 @@ class Analysis(BaseContent):
         """ Returns True if the result is above the Upper Detection
             Limit or if Upper Detection Limit has been manually set
         """
+        dl = self.getDetectionLimitOperand()
+        if dl and dl == '>':
+            return True
         result = self.getResult()
         if result and str(result).strip().startswith('>'):
             return True
@@ -342,7 +360,6 @@ class Analysis(BaseContent):
             except:
                 pass
         return False
-
 
     def getDetectionLimits(self):
         """ Returns a two-value array with the limits of detection
@@ -389,7 +406,32 @@ class Analysis(BaseContent):
     def setResult(self, value, **kw):
         # Always update ResultCapture date when this field is modified
         self.setResultCaptureDate(DateTime())
-        self.getField('Result').set(self, value, **kw)
+        # Only allow DL if manually enabled in AS
+        val = value
+        if val and (val.strip().startswith('>') or val.strip().startswith('<')):
+            oper = '<' if val.strip().startswith('<') else '>'
+            srv = self.getService()
+            if srv and srv.getAllowManualDetectionLimit():
+                # DL allowed, try to remove the operator and set the
+                # result as a detection limit
+                try:
+                    val = val.replace(oper, '', 1);
+                    val = str(float(val))
+                    self.Schema().getField('DetectionLimitOperand').set(self, oper)
+                except:
+                    val = value
+            else:
+                # DL not allowed, try to remove the operator, but only
+                # if the result is floatable.
+                try:
+                    val = val.replace(oper, '', 1);
+                    val = str(float(val))
+                except:
+                    val = value
+        elif not val:
+            # Reset DL
+            self.Schema().getField('DetectionLimitOperand').set(self, None)
+        self.getField('Result').set(self, val, **kw)
 
     def getSample(self):
         # ReferenceSample cannot provide a 'getSample'
@@ -704,13 +746,14 @@ class Analysis(BaseContent):
 
     def getFormattedResult(self, specs=None, decimalmark='.', sciformat=1):
         """Formatted result:
-        1. Print ResultText of matching ResultOptions
-        2. If the result is not floatable, return it without being formatted
-        3. If the analysis specs has hidemin or hidemax enabled and the
+        1. If the result is a detection limit, returns '< LDL' or '> UDL'
+        2. Print ResultText of matching ResultOptions
+        3. If the result is not floatable, return it without being formatted
+        4. If the analysis specs has hidemin or hidemax enabled and the
            result is out of range, render result as '<min' or '>max'
-        4. If the result is below Lower Detection Limit, show '<LDL'
-        5. If the result is above Upper Detecion Limit, show '>UDL'
-        6. Otherwise, render numerical value
+        5. If the result is below Lower Detection Limit, show '<LDL'
+        6. If the result is above Upper Detecion Limit, show '>UDL'
+        7. Otherwise, render numerical value
         specs param is optional. A dictionary as follows:
             {'min': <min_val>,
              'max': <max_val>,
@@ -725,22 +768,35 @@ class Analysis(BaseContent):
                           By default 1
         """
         result = self.getResult()
+
+        # 1. The result is a detection limit, return '< LDL' or '> UDL'
+        dl = self.getDetectionLimitOperand()
+        if dl:
+            try:
+                result = float(result)
+                return formatDecimalMark('%s %s' % (dl, result), decimalmark)
+            except:
+                logger.warn("The result for the analysis %s is a "
+                            "detection limit, but not floatable: %s" %
+                            (self.id, result))
+                return formatDecimalMark(result, decimalmark=decimalmark)
+
         service = self.getService()
         choices = service.getResultOptions()
 
-        # 1. Print ResultText of matching ResulOptions
+        # 2. Print ResultText of matching ResulOptions
         match = [x['ResultText'] for x in choices
                  if str(x['ResultValue']) == str(result)]
         if match:
             return match[0]
 
-        # 2. If the result is not floatable, return it without being formatted
+        # 3. If the result is not floatable, return it without being formatted
         try:
             result = float(result)
         except:
             return formatDecimalMark(result, decimalmark=decimalmark)
 
-        # 3. If the analysis specs has enabled hidemin or hidemax and the
+        # 4. If the analysis specs has enabled hidemin or hidemax and the
         #    result is out of range, render result as '<min' or '>max'
         belowmin = False
         abovemax = False
@@ -758,11 +814,11 @@ class Analysis(BaseContent):
             abovemax = False
             pass
 
-        # 3.1. If result is below min and hidemin enabled, return '<min'
+        # 4.1. If result is below min and hidemin enabled, return '<min'
         if belowmin:
             return formatDecimalMark('< %s' % hidemin, decimalmark)
 
-        # 3.2. If result is above max and hidemax enabled, return '>max'
+        # 4.2. If result is above max and hidemax enabled, return '>max'
         if abovemax:
             return formatDecimalMark('> %s' % hidemax, decimalmark)
 
@@ -1052,7 +1108,6 @@ class Analysis(BaseContent):
             Service=self.getService(),
             Calculation=self.getCalculation(),
             InterimFields=self.getInterimFields(),
-            Result=self.getResult(),
             ResultDM=self.getResultDM(),
             Retested=True,  # True
             MaxTimeAllowed=self.getMaxTimeAllowed(),
@@ -1061,9 +1116,9 @@ class Analysis(BaseContent):
             ReportDryMatter=self.getReportDryMatter(),
             Analyst=self.getAnalyst(),
             Instrument=self.getInstrument(),
-            LowerDetectionLimit=str(self.getLowerDetectionLimit()),
-            UpperDetectionLimit=str(self.getUpperDetectionLimit()),
             SamplePartition=self.getSamplePartition())
+        analysis.setDetectionLimitOperand(self.getDetectionLimitOperand())
+        analysis.setResult(self.getResult())
         analysis.unmarkCreationFlag()
 
         # zope.event.notify(ObjectInitializedEvent(analysis))

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -187,6 +187,16 @@ schema = BikaSchema.copy() + Schema((
             label = _("Uncertainty"),
         ),
     ),
+    FixedPointField('LowerLimitOfDetection',
+        widget=DecimalWidget(
+            label = _("Lower Limit of Detection (LDL)"),
+        ),
+    ),
+    FixedPointField('UpperLimitOfDetection',
+        widget=DecimalWidget(
+            label = _("Upper Limit of Detection (UDL)"),
+        ),
+    ),
 ),
 )
 
@@ -268,6 +278,39 @@ class Analysis(BaseContent):
                 # if uncertainty is not a number, return default value
                 return self.getDefaultUncertainty(result)
         return self.getDefaultUncertainty(result)
+
+    def getLowerDetectionLimit(self):
+        """ Returns the Lower Detection Limit (LDL) that applies to
+            this analysis in particular. If no value set or the
+            analysis service doesn't allow manual input of detection
+            limits, returns the value set by default in the Analysis
+            Service
+        """
+        serv = self.getService()
+        dl = self.Schema().getField('LowerDetectionLimit').get(self)
+        am = serv.getAllowManualDetectionLimit()
+        return dl if (dl and am) else serv.getLowerDetectionLimit()
+
+    def getUpperDetectionLimit(self):
+        """ Returns the Upper Detection Limit (UDL) that applies to
+            this analysis in particular. If no value set or the
+            analysis service doesn't allow manual input of detection
+            limits, returns the value set by default in the Analysis
+            Service
+        """
+        serv = self.getService()
+        dl = self.Schema().getField('UpperDetectionLimit').get(self)
+        am = serv.getAllowManualDetectionLimit()
+        return dl if (dl and am) else serv.getUpperDetectionLimit()
+
+    def getDetectionLimits(self):
+        """ Returns a two-value array with the limits of detection
+            (LDL and UDL) that applies to this analysis in particular.
+            If no value set or the analysis service doesn't allow
+            manual input of detection limits, returns the value set by
+            default in the Analysis Service
+        """
+        return [getLowerDetectionLimit(), getUpperDetectionLimit()]
 
     def getDependents(self):
         """ Return a list of analyses who depend on us

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -321,7 +321,7 @@ class Analysis(BaseContent):
                             "detection limit, but not floatable: '%s'. "
                             "Returnig AS's default LDL." %
                             (self.id, result))
-        return self.getService().getLowerDetectionLimit()
+        return self.getService().getUpperDetectionLimit()
 
     def isBelowLowerDetectionLimit(self):
         """ Returns True if the result is below the Lower Detection

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -239,6 +239,45 @@ schema = BikaSchema.copy() + Schema((
                          "notation.  The default is 7."),
                  ),
     ),
+    FixedPointField('LowerDetectionLimit',
+                    schemata="Analysis",
+                    default='0.00',
+                    widget=DecimalWidget(
+                        label = _("Lower Detection Limit (LDL)"),
+                        description = _("The Lower Detection Limit is "
+                                        "the lowest value to which the "
+                                        "measured parameter can be "
+                                        "measured using the specified "
+                                        "testing methodology. Results "
+                                        "entered which are less than "
+                                        "this value will be reported "
+                                        "as < LDL")
+                    ),
+    ),
+    FixedPointField('UpperDetectionLimit',
+                schemata="Analysis",
+                default='0.00',
+                widget=DecimalWidget(
+                    label = _("Upper Detection Limit (UDL)"),
+                    description = _("The Upper Detection Limit is the "
+                                    "highest value to which the "
+                                    "measured parameter can be measured "
+                                    "using the specified testing "
+                                    "methodology. Results entered "
+                                    "which are greater than this value "
+                                    "will be reported as > UDL")
+                ),
+    ),
+    BooleanField('AllowManualDetectionLimit',
+             schemata="Analysis",
+             default=False,
+             widget=BooleanWidget(
+                label = _("Allow Manual Detection Limit input"),
+                description = _("Allow the analyst to manually "
+                                "replace the default Detection Limits "
+                                "(LDL and UDL) on results entry views"),
+             ),
+    ),
     BooleanField('ReportDryMatter',
                  schemata="Analysis",
                  default=False,
@@ -1078,12 +1117,12 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
 
                     return unc
         return None
-  
 
 
-     
 
-	
+
+
+
     def getPrecision(self, result=None):
         """
         Returns the precision for the Analysis Service. If the

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -256,7 +256,7 @@ schema = BikaSchema.copy() + Schema((
     ),
     FixedPointField('UpperDetectionLimit',
                 schemata="Analysis",
-                default='0.00',
+                default='1000.00',
                 widget=DecimalWidget(
                     label = _("Upper Detection Limit (UDL)"),
                     description = _("The Upper Detection Limit is the "
@@ -1084,7 +1084,6 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         items.sort(lambda x, y: cmp(x[1], y[1]))
         return DisplayList(list(items))
 
-
     def getUncertainty(self, result=None):
         """
         Return the uncertainty value, if the result falls within
@@ -1118,10 +1117,25 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
                     return unc
         return None
 
+    def getLowerDetectionLimit(self):
+        """ Returns the Lower Detection Limit for this service as a
+            floatable
+        """
+        ldl = self.Schema().getField('LowerDetectionLimit').get(self)
+        try:
+            return float(ldl)
+        except ValueError:
+            return 0
 
-
-
-
+    def getUpperDetectionLimit(self):
+        """ Returns the Upper Detection Limit for this service as a
+            floatable
+        """
+        udl = self.Schema().getField('UpperDetectionLimit').get(self)
+        try:
+            return float(udl)
+        except ValueError:
+            return 0
 
     def getPrecision(self, result=None):
         """

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -13,6 +13,7 @@ from bika.lims.config import STD_TYPES, PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.subscribers import skip
+from bika.lims.utils.analysis import get_significant_digits
 from DateTime import DateTime
 from plone.app.blob.field import BlobField
 from Products.Archetypes.config import REFERENCE_CATALOG

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -1,0 +1,161 @@
+from bika.lims import logger
+from bika.lims.content.analysis import Analysis
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.workflow import doActionFor
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError: # Python 2.7
+    import unittest
+
+
+class TestLimitDetections(BikaFunctionalTestCase):
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestLimitDetections, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+        servs = self.portal.bika_setup.bika_analysisservices
+        # analysis-service-3: Calcium (Ca)
+        # analysis-service-6: Cooper (Cu)
+        # analysis-service-7: Iron (Fe)
+        self.services = [servs['analysisservice-3'],
+                         servs['analysisservice-6'],
+                         servs['analysisservice-7']]
+        self.lds = [{'min': '0.0',  'max': '1000.0', 'manual': False},
+                    {'min': '10.0', 'max': '20.0',   'manual': True},
+                    {'min': '0.0',  'max': '20.0',   'manual': True}]
+        idx = 0
+        for s in self.services:
+            s.setAllowManualDetectionLimit(self.lds[idx]['manual'])
+            s.setLowerDetectionLimit(self.lds[idx]['min'])
+            s.setUpperDetectionLimit(self.lds[idx]['max'])
+            idx+=1
+
+    def tearDown(self):
+        for s in self.services:
+            s.setAllowManualDetectionLimit(False)
+            s.setLowerDetectionLimit(str(0))
+            s.setUpperDetectionLimit(str(1000))
+        logout()
+        super(TestLimitDetections, self).tearDown()
+
+    def test_ar_manageresults_limitdetections(self):
+        # Input results
+        # Client:       Happy Hills
+        # SampleType:   Apple Pulp
+        # Contact:      Rita Mohale
+        # Analyses:     [Calcium, Copper]
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        request = {}
+        services = [s.UID() for s in self.services]
+        ar = create_analysisrequest(client, request, values, services)
+
+        # Basic detection limits
+        asidxs = {'analysisservice-3': 0,
+                  'analysisservice-6': 1,
+                  'analysisservice-7': 2}
+        for a in ar.getAnalyses():
+            an = a.getObject()
+            idx = asidxs[an.getService().id]
+            self.assertEqual(an.getLowerDetectionLimit(), float(self.lds[idx]['min']))
+            self.assertEqual(an.getUpperDetectionLimit(), float(self.lds[idx]['max']))
+            self.assertEqual(an.getService().getAllowManualDetectionLimit(), self.lds[idx]['manual'])
+
+            # Empty result
+            self.assertFalse(an.getDetectionLimitOperand())
+            self.assertFalse(an.isBelowLowerDetectionLimit())
+            self.assertFalse(an.isAboveUpperDetectionLimit())
+
+            # Set a result
+            an.setResult('15')
+            self.assertEqual(float(an.getResult()), 15)
+            self.assertFalse(an.isBelowLowerDetectionLimit())
+            self.assertFalse(an.isAboveUpperDetectionLimit())
+            self.assertFalse(an.getDetectionLimitOperand())
+            self.assertEqual(an.getFormattedResult(), '15')
+            an.setResult('-1')
+            self.assertEqual(float(an.getResult()), -1)
+            self.assertTrue(an.isBelowLowerDetectionLimit())
+            self.assertFalse(an.isAboveUpperDetectionLimit())
+            self.assertFalse(an.getDetectionLimitOperand())
+            self.assertEqual(an.getFormattedResult(), '< %s' % (self.lds[idx]['min']))
+            an.setResult('2000')
+            self.assertEqual(float(an.getResult()), 2000)
+            self.assertFalse(an.isBelowLowerDetectionLimit())
+            self.assertTrue(an.isAboveUpperDetectionLimit())
+            self.assertFalse(an.getDetectionLimitOperand())
+            self.assertEqual(an.getFormattedResult(), '> %s' % (self.lds[idx]['max']))
+
+            # Set a DL result
+            an.setResult('<15')
+            self.assertEqual(float(an.getResult()), 15)
+            if self.lds[idx]['manual']:
+                self.assertTrue(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertEqual(an.getDetectionLimitOperand(), '<')
+                self.assertEqual(an.getFormattedResult(), '< 15.0')
+            else:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(), '15')
+
+            an.setResult('>15')
+            self.assertEqual(float(an.getResult()), 15)
+            if self.lds[idx]['manual']:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertTrue(an.isAboveUpperDetectionLimit())
+                self.assertEqual(an.getDetectionLimitOperand(), '>')
+                self.assertEqual(an.getFormattedResult(), '> 15.0')
+            else:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(), '15')
+
+            # Set a DL result explicitely
+            an.setDetectionLimitOperand('<')
+            an.setResult('15')
+            self.assertEqual(float(an.getResult()), 15)
+            if self.lds[idx]['manual']:
+                self.assertTrue(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertEqual(an.getDetectionLimitOperand(), '<')
+                self.assertEqual(an.getFormattedResult(), '< 15.0')
+            else:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(), '15')
+
+            an.setDetectionLimitOperand('>')
+            an.setResult('15')
+            self.assertEqual(float(an.getResult()), 15)
+            if self.lds[idx]['manual']:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertTrue(an.isAboveUpperDetectionLimit())
+                self.assertEqual(an.getDetectionLimitOperand(), '>')
+                self.assertEqual(an.getFormattedResult(), '> 15.0')
+            else:
+                self.assertFalse(an.isBelowLowerDetectionLimit())
+                self.assertFalse(an.isAboveUpperDetectionLimit())
+                self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(), '15')
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestLimitDetections))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input
 LIMS-1324: Allow to hide analyses in results reports
 LIMS-1754: Easy install for LIMS' add-ons was not possible


### PR DESCRIPTION
- Lower and Upper Detection Limits fields in AS (LDL and UDL)
- "Allow manual Detection Limit" field in AS
- In manage_results, if an analysis has the manual detection limit set to true, allow the user/analyst to set a detection limit
- Results formatting with LDL and UDL

```
jordi@darwin:~/dev/labsanmartin/bikalims/zinstance$ bin/test -s bika.lims -t TestLimitDetections
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.154 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.113 seconds.
  Set up bika.lims.testing.BikaTestLayer in 42.882 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                
  Ran 1 tests with 0 failures and 0 errors in 1.832 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.013 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.050 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.003 seconds.
```
