### PR TITLE
LIMS-1775 Allow to select LDL or UDL defaults in results with readonly mode

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -600,11 +600,13 @@ class AnalysesView(BikaListingView):
                     items[i]['after']['Uncertainty'] = '<em class="discreet" style="white-space:nowrap;"> %s</em>' % items[i]['Unit'];
 
                 # LIMS-1700. Allow manual input of Detection Limits
+                # LIMS-1775. Allow to select LDL or UDL defaults in results with readonly mode
                 # https://jira.bikalabs.com/browse/LIMS-1700
+                # https://jira.bikalabs.com/browse/LIMS-1775
                 if can_edit_analysis and \
                     hasattr(obj, 'getDetectionLimitOperand') and \
-                    hasattr(service, 'getAllowManualDetectionLimit') and \
-                    service.getAllowManualDetectionLimit() == True:
+                    hasattr(service, 'getDetectionLimitSelector') and \
+                    service.getDetectionLimitSelector() == True:
                     isldl = obj.isBelowLowerDetectionLimit()
                     isudl = obj.isAboveUpperDetectionLimit()
                     dlval=''
@@ -618,7 +620,8 @@ class AnalysesView(BikaListingView):
                     self.columns['DetectionLimit']['toggle'] = True
                     srv = obj.getService()
                     defdls = {'min':srv.getLowerDetectionLimit(),
-                              'max':srv.getUpperDetectionLimit()}
+                              'max':srv.getUpperDetectionLimit(),
+                              'manual':srv.getAllowManualDetectionLimit()}
                     defin = '<input type="hidden" id="DefaultDLS.%s" value=\'%s\'/>'
                     defin = defin % (obj.UID(), json.dumps(defdls))
                     item['after']['DetectionLimit'] = defin
@@ -635,7 +638,8 @@ class AnalysesView(BikaListingView):
                            'above_udl': False,
                            'is_ldl': False,
                            'is_udl': False,
-                           'manual_allowed': False}
+                           'manual_allowed': False,
+                           'dlselect_allowed': False}
                     if hasattr(obj, 'getDetectionLimits'):
                         dls['below_ldl'] = obj.isBelowLowerDetectionLimit()
                         dls['above_udl'] = obj.isBelowLowerDetectionLimit()
@@ -644,6 +648,7 @@ class AnalysesView(BikaListingView):
                         dls['default_ldl'] = service.getLowerDetectionLimit()
                         dls['default_udl'] = service.getUpperDetectionLimit()
                         dls['manual_allowed'] = service.getAllowManualDetectionLimit()
+                        dls['dlselect_allowed'] = service.getDetectionLimitSelector()
                     dlsin = '<input type="hidden" id="AnalysisDLS.%s" value=\'%s\'/>'
                     dlsin = dlsin % (obj.UID(), json.dumps(dls))
                     item['after']['Result'] = dlsin

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -623,6 +623,31 @@ class AnalysesView(BikaListingView):
                     defin = defin % (obj.UID(), json.dumps(defdls))
                     item['after']['DetectionLimit'] = defin
 
+                # LIMS-1768. Allow to use LDL and UDL in calculations.
+                # https://jira.bikalabs.com/browse/LIMS-1769
+                # Since LDL, UDL, etc. are wildcards that can be used
+                # in calculations, these fields must be loaded always
+                # for 'live' calculations.
+                if can_edit_analysis:
+                    dls = {'default_ldl': 'none',
+                           'default_udl': 'none',
+                           'below_ldl': False,
+                           'above_udl': False,
+                           'is_ldl': False,
+                           'is_udl': False,
+                           'manual_allowed': False}
+                    if hasattr(obj, 'getDetectionLimits'):
+                        dls['below_ldl'] = obj.isBelowLowerDetectionLimit()
+                        dls['above_udl'] = obj.isBelowLowerDetectionLimit()
+                        dls['is_ldl'] = obj.isLowerDetectionLimit()
+                        dls['is_udl'] = obj.isUpperDetectionLimit()
+                        dls['default_ldl'] = srv.getLowerDetectionLimit()
+                        dls['default_udl'] = srv.getUpperDetectionLimit()
+                        dls['manual_allowed'] = srv.getAllowManualDetectionLimit()
+                    dlsin = '<input type="hidden" id="AnalysisDLS.%s" value=\'%s\'/>'
+                    dlsin = dlsin % (obj.UID(), json.dumps(dls))
+                    item['after']['Result'] = dlsin
+
             else:
                 items[i]['Specification'] = ""
                 if 'Result' in items[i]['allow_edit']:

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -623,7 +623,7 @@ class AnalysesView(BikaListingView):
                     defin = defin % (obj.UID(), json.dumps(defdls))
                     item['after']['DetectionLimit'] = defin
 
-                # LIMS-1768. Allow to use LDL and UDL in calculations.
+                # LIMS-1769. Allow to use LDL and UDL in calculations.
                 # https://jira.bikalabs.com/browse/LIMS-1769
                 # Since LDL, UDL, etc. are wildcards that can be used
                 # in calculations, these fields must be loaded always

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -641,9 +641,9 @@ class AnalysesView(BikaListingView):
                         dls['above_udl'] = obj.isBelowLowerDetectionLimit()
                         dls['is_ldl'] = obj.isLowerDetectionLimit()
                         dls['is_udl'] = obj.isUpperDetectionLimit()
-                        dls['default_ldl'] = srv.getLowerDetectionLimit()
-                        dls['default_udl'] = srv.getUpperDetectionLimit()
-                        dls['manual_allowed'] = srv.getAllowManualDetectionLimit()
+                        dls['default_ldl'] = service.getLowerDetectionLimit()
+                        dls['default_udl'] = service.getUpperDetectionLimit()
+                        dls['manual_allowed'] = service.getAllowManualDetectionLimit()
                     dlsin = '<input type="hidden" id="AnalysisDLS.%s" value=\'%s\'/>'
                     dlsin = dlsin % (obj.UID(), json.dumps(dls))
                     item['after']['Result'] = dlsin

--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -112,7 +112,7 @@ class ajaxCalculateAnalysisEntry(BrowserView):
                     unsatisfied = True
                     break
 
-                # LIMS-1768. Allow to use LDL and UDL in calculations.
+                # LIMS-1769. Allow to use LDL and UDL in calculations.
                 # https://jira.bikalabs.com/browse/LIMS-1769
                 analysisvalues = {}
                 if dependency_uid in self.current_results:

--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -90,26 +90,42 @@ class ajaxCalculateAnalysisEntry(BrowserView):
                 Result['result'] = ""
 
         if calculation:
-            # add all our dependent analyses results to the mapping.
-            # Retrieve value from database if it's not in the current_results.
+
+            '''
+             We need first to create the map of available parameters
+             acording to the interims, analyses and wildcards:
+             params = {
+                    <as-1-keyword>              : <analysis_result>,
+                    <as-1-keyword>.<wildcard-1> : <wildcard_1_value>,
+                    <as-1-keyword>.<wildcard-2> : <wildcard_2_value>,
+                    <interim-1>                 : <interim_result>,
+                    ...
+                    }
+            '''
+
+            # Get dependent analyses results and wildcard values to the
+            # mapping. If dependent analysis without result found,
+            # break and abort calculation
             unsatisfied = False
             for dependency_uid, dependency in deps.items():
                 if dependency_uid in self.ignore_uids:
                     unsatisfied = True
                     break
-                if dependency_uid in self.current_results:
-                    result = self.current_results[dependency_uid]
-                else:
-                    result = dependency.getResult()
+                result = self.current_results.get(dependency_uid, dependency.getResult())
                 if result == '':
                     unsatisfied = True
                     break
                 key = dependency.getService().getKeyword()
-                # All mappings must be float, or they are ignored.
+
+                # Analysis result
+                # All result mappings must be float, or they are ignored.
                 try:
                     mapping[key] = float(self.current_results[dependency_uid])
                 except:
-                    pass
+                    # If result is not floatable, then abort!
+                    unsatisfied = True
+                    break
+
             if unsatisfied:
                 # unsatisfied means that one or more result on which we depend
                 # is blank or unavailable, so we set blank result and abort.

--- a/bika/lims/browser/js/bika.lims.analysisservice.js
+++ b/bika/lims/browser/js/bika.lims.analysisservice.js
@@ -24,11 +24,26 @@ function AnalysisServiceEditView() {
     var acalc_sel  = $('#archetypes-fieldname-DeferredCalculation #DeferredCalculation');
     var interim_fd = $("#archetypes-fieldname-InterimFields");
     var interim_rw = $("#archetypes-fieldname-InterimFields tr.records_row_InterimFields");
+    var ldsel_chk  = $('#archetypes-fieldname-DetectionLimitSelector #DetectionLimitSelector');
+    var ldman_fd   = $('#archetypes-fieldname-AllowManualDetectionLimit');
+    var ldman_chk  = $('#archetypes-fieldname-AllowManualDetectionLimit #AllowManualDetectionLimit');
 
     /**
      * Entry-point method for AnalysisServiceEditView
      */
     that.load = function() {
+
+        // LIMS-1775 Allow to select LDL or UDL defaults in results with readonly mode
+        // https://jira.bikalabs.com/browse/LIMS-1775
+        $(ldsel_chk).change(function() {
+            if ($(this).is(':checked')) {
+                $(ldman_fd).show();
+            } else {
+                $(ldman_fd).hide();
+                $(ldman_chk).prop('checked', false);
+            }
+        });
+        $(ldsel_chk).change();
 
         // service defaults
         // update defalt Containers

--- a/bika/lims/browser/js/bika.lims.utils.calcs.js
+++ b/bika/lims/browser/js/bika.lims.utils.calcs.js
@@ -58,7 +58,7 @@ function CalculationUtils() {
                 var result = $(e).val();
 
                 /**
-                 * LIMS-1768. Allow to use LDL and UDL in calculations.
+                 * LIMS-1769. Allow to use LDL and UDL in calculations.
                  * https://jira.bikalabs.com/browse/LIMS-1769
                  */
                 var andls = $.parseJSON($(tr).find('input[id^="AnalysisDLS."]').val());

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -276,14 +276,19 @@ function WorksheetManageResultsView() {
             var defdls = $(this).closest('td').find('input[id^="DefaultDLS."]').first().val();
             var resfld = $(this).closest('tr').find('input[name^="Result."]')[0];
             defdls = $.parseJSON(defdls);
+            $(resfld).prop('readonly', !defdls.manual);
             if ($(this).val() == '<') {
                 $(resfld).val(defdls['min']);
             } else if ($(this).val() == '>') {
                 $(resfld).val(defdls['max']);
             } else {
                 $(resfld).val('');
+                $(resfld).prop('readonly',false);
             }
+            // Maybe the result is used in calculations...
+            $(resfld).change();
         });
+        $('select[name^="DetectionLimit."]').change();
     }
 
     function loadWideInterimsEventHandlers() {

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -808,6 +808,7 @@ class Analysis(BaseContent):
         dl = self.getDetectionLimitOperand()
         if dl:
             try:
+                result = float(result)
                 result = format_numeric_result(self, result, sciformat=sciformat)
                 return formatDecimalMark('%s %s' % (dl, result), decimalmark)
             except:

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -276,8 +276,17 @@ class Analysis(BaseContent):
     def setDetectionLimitOperand(self, value):
         """ Sets the detection limit operand for this analysis, so
             the result will be interpreted as a detection limit.
+            The value will only be set if the Service has
+            'DetectionLimitSelector' field set to True, otherwise,
+            the detection limit operand will be set to None.
+            See LIMS-1775 for further information about the relation
+            amongst 'DetectionLimitSelector' and
+            'AllowManualDetectionLimit'.
+            https://jira.bikalabs.com/browse/LIMS-1775
         """
-        val = value if value in ('>', '<') else None
+        srv = self.getService()
+        md = srv.getDetectionLimitSelector() if srv else False
+        val = value if (md and value in ('>', '<')) else None
         self.Schema().getField('DetectionLimitOperand').set(self, val)
 
     def getLowerDetectionLimit(self):

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -808,7 +808,7 @@ class Analysis(BaseContent):
         dl = self.getDetectionLimitOperand()
         if dl:
             try:
-                result = float(result)
+                result = format_numeric_result(self, result, sciformat=sciformat)
                 return formatDecimalMark('%s %s' % (dl, result), decimalmark)
             except:
                 logger.warn("The result for the analysis %s is a "
@@ -860,12 +860,12 @@ class Analysis(BaseContent):
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()
         if result < ldl:
-            return formatDecimalMark('< %s' % ldl, decimalmark)
+            return formatDecimalMark('< %s' % format_numeric_result(self, ldl, sciformat=sciformat), decimalmark)
 
         # Above Upper Detection Limit (UDL)?
         udl = self.getUpperDetectionLimit()
         if result > udl:
-            return formatDecimalMark('> %s' % udl, decimalmark)
+            return formatDecimalMark('> %s' % format_numeric_result(self, udl, sciformat=sciformat), decimalmark)
 
         # Render numerical values
         return formatDecimalMark(format_numeric_result(self, result, sciformat=sciformat), decimalmark=decimalmark)

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -276,13 +276,8 @@ class Analysis(BaseContent):
     def setDetectionLimitOperand(self, value):
         """ Sets the detection limit operand for this analysis, so
             the result will be interpreted as a detection limit.
-            The value will only be set if the Service has 'Allow manual
-            detection limit' field set to True, otherwise, the detection
-            limit operand will be set to None.
         """
-        srv = self.getService()
-        md = srv.getAllowManualDetectionLimit() if srv else False
-        val = value if (md and value in ('>', '<')) else None
+        val = value if value in ('>', '<') else None
         self.Schema().getField('DetectionLimitOperand').set(self, val)
 
     def getLowerDetectionLimit(self):

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -375,14 +375,14 @@ class Analysis(BaseContent):
             a Lower Detection Limit. Otherwise, returns False
         """
         return self.isBelowLowerDetectionLimit() and \
-                obj.getDetectionLimitOperand() == '<'
+                self.getDetectionLimitOperand() == '<'
 
     def isUpperDetectionLimit(self):
         """ Returns True if the result for this analysis represents
             an Upper Detection Limit. Otherwise, returns False
         """
-        return self.isBelowLowerDetectionLimit() and \
-                obj.getDetectionLimitOperand() == '>'
+        return self.isAboveUpperDetectionLimit() and \
+                self.getDetectionLimitOperand() == '>'
 
     def getDependents(self):
         """ Return a list of analyses who depend on us
@@ -535,46 +535,33 @@ class Analysis(BaseContent):
         """ Calculates the result for the current analysis if it depends of
             other analysis/interim fields. Otherwise, do nothing
         """
-
         if self.getResult() and override == False:
             return False
 
-        calculation = self.getService().getCalculation()
-        if not calculation:
+        serv = self.getService()
+        calc = self.getCalculation() if self.getCalculation() \
+                                     else serv.getCalculation()
+        if not calc:
             return False
 
         mapping = {}
 
+        # Interims' priority order (from low to high):
+        # Calculation < Analysis Service < Analysis
+        interims = calc.getInterimFields() + \
+                   serv.getInterimFields() + \
+                   self.getInterimFields()
+
         # Add interims to mapping
-        for interimdata in self.getInterimFields():
-            for i in interimdata:
-                try:
-                    ivalue = float(i['value'])
-                    mapping[i['keyword']] = ivalue
-                except:
-                    # Interim not float, abort
-                    return False
-
-        # Add calculation's hidden interim fields to mapping
-        for field in calculation.getInterimFields():
-            if field['keyword'] not in mapping.keys():
-                if field.get('hidden', False):
-                    try:
-                        ivalue = float(field['value'])
-                        mapping[field['keyword']] = ivalue
-                    except:
-                        return False
-
-        # Add Analysis Service interim defaults to mapping
-        service = self.getService()
-        for field in service.getInterimFields():
-            if field['keyword'] not in mapping.keys():
-                if field.get('hidden', False):
-                    try:
-                        ivalue = float(field['value'])
-                        mapping[field['keyword']] = ivalue
-                    except:
-                        return False
+        for i in interims:
+            if 'keyword' not in i:
+                continue;
+            try:
+                ivalue = float(i['value'])
+                mapping[i['keyword']] = ivalue
+            except:
+                # Interim not float, abort
+                return False
 
         # Add dependencies results to mapping
         dependencies = self.getDependencies()
@@ -597,7 +584,7 @@ class Analysis(BaseContent):
                     bdl = dependency.isBelowLowerDetectionLimit()
                     adl = dependency.isAboveUpperDetectionLimit()
                     mapping[key]=result
-                    mapping['%s.%s' % (key, 'RESULT')]=ivalue
+                    mapping['%s.%s' % (key, 'RESULT')]=result
                     mapping['%s.%s' % (key, 'LDL')]=ldl
                     mapping['%s.%s' % (key, 'UDL')]=udl
                     mapping['%s.%s' % (key, 'BELOWLDL')]=int(bdl)
@@ -606,7 +593,7 @@ class Analysis(BaseContent):
                     return False
 
         # Calculate
-        formula = calculation.getMinifiedFormula()
+        formula = calc.getMinifiedFormula()
         formula = formula.replace('[', '%(').replace(']', ')f')
         try:
             formula = eval("'%s'%%mapping" % formula,
@@ -625,7 +612,7 @@ class Analysis(BaseContent):
             self.setResult("NA")
             return True
 
-        self.setResult(result)
+        self.setResult(str(result))
         return True
 
     def getPriority(self):

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -370,6 +370,20 @@ class Analysis(BaseContent):
         """
         return [self.getLowerDetectionLimit(), self.getUpperDetectionLimit()]
 
+    def isLowerDetectionLimit(self):
+        """ Returns True if the result for this analysis represents
+            a Lower Detection Limit. Otherwise, returns False
+        """
+        return self.isBelowLowerDetectionLimit() and \
+                obj.getDetectionLimitOperand() == '<'
+
+    def isUpperDetectionLimit(self):
+        """ Returns True if the result for this analysis represents
+            an Upper Detection Limit. Otherwise, returns False
+        """
+        return self.isBelowLowerDetectionLimit() and \
+                obj.getDetectionLimitOperand() == '>'
+
     def getDependents(self):
         """ Return a list of analyses who depend on us
             to calculate their result

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -586,19 +586,22 @@ class Analysis(BaseContent):
                     # Try to calculate the dependency result
                     dependency.calculateResult(override, cascade)
                     result = dependency.getResult()
-                    if result:
-                        try:
-                            result = float(str(result))
-                            mapping[dependency.getKeyword()] = result
-                        except:
-                            return False
                 else:
                     return False
-            else:
-                # Result must be float
+            if result:
                 try:
                     result = float(str(result))
-                    mapping[dependency.getKeyword()] = result
+                    key = dependency.getKeyword()
+                    ldl = dependency.getLowerDetectionLimit()
+                    udl = dependency.getUpperDetectionLimit()
+                    bdl = dependency.isBelowLowerDetectionLimit()
+                    adl = dependency.isAboveUpperDetectionLimit()
+                    mapping[key]=result
+                    mapping['%s.%s' % (key, 'RESULT')]=ivalue
+                    mapping['%s.%s' % (key, 'LDL')]=ldl
+                    mapping['%s.%s' % (key, 'UDL')]=udl
+                    mapping['%s.%s' % (key, 'BELOWLDL')]=int(bdl)
+                    mapping['%s.%s' % (key, 'ABOVEUDL')]=int(adl)
                 except:
                     return False
 

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -268,6 +268,44 @@ schema = BikaSchema.copy() + Schema((
                                     "will be reported as > UDL")
                 ),
     ),
+    # LIMS-1775 Allow to select LDL or UDL defaults in results with readonly mode
+    # https://jira.bikalabs.com/browse/LIMS-1775
+    # Some behavior controlled with javascript: If checked, the field
+    # "AllowManualDetectionLimit" will be displayed.
+    # See browser/js/bika.lims.analysisservice.edit.js
+    #
+    # Use cases:
+    # a) If "DetectionLimitSelector" is enabled and
+    # "AllowManualDetectionLimit" is enabled too, then:
+    # the analyst will be able to select an '>', '<' operand from the
+    # selection list and also set the LD manually.
+    #
+    # b) If "DetectionLimitSelector" is enabled and
+    # "AllowManualDetectionLimit" is unchecked, the analyst will be
+    # able to select an operator from the selection list, but not set
+    # the LD manually: the default LD will be displayed in the result
+    # field as usuall, but in read-only mode.
+    #
+    # c) If "DetectionLimitSelector" is disabled, no LD selector will be
+    # displayed in the results table.
+    BooleanField('DetectionLimitSelector',
+        schemata="Analysis",
+        default=False,
+        widget=BooleanWidget(
+            label = _("Display a Detection Limit selector"),
+            description = _("If checked, a selection list will be "
+                            "displayed next to the analysis' result "
+                            "field in results entry views. By using "
+                            "this selector, the analyst will be able "
+                            "to set the value as a Detection Limit "
+                            "(LDL or UDL) instead of a regular result"),
+        ),
+    ),
+    # Behavior controlled with javascript: Only visible when the
+    # "DetectionLimitSelector" is checked
+    # See browser/js/bika.lims.analysisservice.edit.js
+    # Check inline comment for "DetecionLimitSelector" field for
+    # further information.
     BooleanField('AllowManualDetectionLimit',
              schemata="Analysis",
              default=False,

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -113,7 +113,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             self.getField('Formula').set(self, Formula)
         else:
             DependentServices = []
-            keywords = re.compile(r"\[([^\]]+)\]").findall(Formula)
+            keywords = re.compile(r"\[([^\.^\]]+)\]").findall(Formula)
             for keyword in keywords:
                 service = bsc(portal_type="AnalysisService",
                               getKeyword=keyword)

--- a/bika/lims/exportimport/setupdata/__init__.py
+++ b/bika/lims/exportimport/setupdata/__init__.py
@@ -1062,7 +1062,7 @@ class Calculations(WorksheetImporter):
             calc_interims = self.interim_fields.get(calc_title, [])
             formula = row['Formula']
             # scan formula for dep services
-            keywords = re.compile(r"\[([^\]]+)\]").findall(formula)
+            keywords = re.compile(r"\[([^\.^\]]+)\]").findall(formula)
             # remove interims from deps
             interim_keys = [k['keyword'] for k in calc_interims]
             dep_keywords = [k for k in keywords if k not in interim_keys]

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1169,5 +1169,22 @@ a.print_button,
 #content div.arresultsinterpretation-container .mceButton.mce_save, {
     display:none;
 }
-
+.bika-listing-table td.interim input[type="text"]:-moz-read-only,
+.bika-listing-table td.Result input[type="text"]:-moz-read-only {
+    color: #555;
+    cursor: not-allowed;
+}
+.bika-listing-table td.interim input[type="text"]:-moz-read-only:focus,
+.bika-listing-table td.Result input[type="text"]:-moz-read-only:focus{
+    background-color: transparent;
+}
+.bika-listing-table td.interim input[type="text"]:read-only,
+.bika-listing-table td.Result input[type="text"]:read-onl {
+    color: #555;
+    cursor: not-allowed;
+}
+.bika-listing-table td.interim input[type="text"]:read-only:focus,
+.bika-listing-table td.Result input[type="text"]:read-only:focus {
+    background-color: transparent;
+}
 </dtml-with>

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -40,6 +40,7 @@ class TestCalculations(BikaFunctionalTestCase):
         for s in self.services:
             s.setLowerDetectionLimit('10')
             s.setUpperDetectionLimit('20')
+            s.setDetectionLimitSelector(True)
             s.setAllowManualDetectionLimit(True)
 
         # Formulas to test

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -1,0 +1,196 @@
+from bika.lims import logger
+from bika.lims.content.analysis import Analysis
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.workflow import doActionFor
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError: # Python 2.7
+    import unittest
+
+
+class TestCalculations(BikaFunctionalTestCase):
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestCalculations, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+
+        # Calculation: Total Hardness
+        # Initial formula: [Ca] + [Mg]
+        calcs = self.portal.bika_setup.bika_calculations
+        self.calculation = [calcs[k] for k in calcs if calcs[k].title=='Total Hardness'][0]
+
+        # Service with calculation: Tot. Harndess (THCaCO3)
+        servs = self.portal.bika_setup.bika_analysisservices
+        self.calcservice = [servs[k] for k in servs if servs[k].title=='Tot. Hardness (THCaCO3)'][0]
+        self.calcservice.setUseDefaultCalculation(False)
+        self.calcservice.setDeferredCalculation(self.calculation)
+        self.calcservice.setLowerDetectionLimit('10')
+        self.calcservice.setUpperDetectionLimit('20')
+        self.calcservice.setAllowManualDetectionLimit(True)
+
+        # Analysis Services: Ca and Mg
+        self.services = self.calculation.getDependentServices()
+
+        # Formulas to test
+        self.formulas = [
+            {'formula' : '[Ca]+[Mg]',
+             'analyses': {'Ca':'10', 'Mg': '15'},
+             'interims': {},
+             'exresult': '25'
+            },
+
+            {'formula' : '[Ca]+[Mg]',
+             'analyses': {'Ca':'-20', 'Mg': '5'},
+             'interims': {},
+             'exresult': '-15'
+            },
+
+            {'formula' : '[Ca]+[Mg]+[IN1]',
+             'analyses': {'Ca': '10', 'Mg': '15'},
+             'interims': {'IN1':'2'},
+             'exresult': '27'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '5', 'Mg': '1'},
+             'interims': {'IN1':'5'},
+             'exresult': '15'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '10', 'Mg': '1'},
+             'interims': {'IN1':'5'},
+             'exresult': '16'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '10', 'Mg': '2'},
+             'interims': {'IN1':'5'},
+             'exresult': '17'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '15', 'Mg': '2'},
+             'interims': {'IN1':'5'},
+             'exresult': '22'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '15', 'Mg': '3'},
+             'interims': {'IN1':'5'},
+             'exresult': '23'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '20', 'Mg': '3'},
+             'interims': {'IN1':'5'},
+             'exresult': '28'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '20', 'Mg': '3'},
+             'interims': {'IN1':'10'},
+             'exresult': '33'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '30', 'Mg': '3'},
+             'interims': {'IN1':'10'},
+             'exresult': '50'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '>30', 'Mg': '5'},
+             'interims': {'IN1':'10'},
+             'exresult': '60'
+            },
+
+            {'formula' : '([Ca]+[Ca.LDL]) if [Ca.BELOWLDL] else (([Ca.UDL] + [Ca]) if [Ca.ABOVEUDL] else [Ca.RESULT] + [Mg] + [IN1])',
+             'analyses': {'Ca': '<5', 'Mg': '5'},
+             'interims': {'IN1':'10'},
+             'exresult': '10'
+            },
+        ]
+
+    def tearDown(self):
+        # Service with calculation: Tot. Harndess (THCaCO3)
+        self.calculation.setFormula('[Ca] + [Mg]')
+        self.calcservice.setUseDefaultCalculation(True)
+        self.calcservice.setLowerDetectionLimit('0')
+        self.calcservice.setUpperDetectionLimit('10000')
+        self.calcservice.setAllowManualDetectionLimit(False)
+        super(TestCalculations, self).tearDown()
+
+    def test_ar_calculations(self):
+        # Input results
+        # Client:       Happy Hills
+        # SampleType:   Apple Pulp
+        # Contact:      Rita Mohale
+        # Analyses:     [Calcium, Mg, Total Hardness]
+        for f in self.formulas:
+            # Set custom calculation
+            self.calculation.setFormula(f['formula'])
+            self.assertEqual(self.calculation.getFormula(), f['formula'])
+            interims = []
+            for k,v in f['interims']:
+                interims.append({'keyword': k, 'title':k, 'value': v,
+                                 'hidden': False, 'type': 'int',
+                                 'unit': ''});
+            self.calculation.setInterimFields(interims)
+            self.assertEqual(self.calculation.getInterimFields(), interims)
+
+            # Create the AR
+            client = self.portal.clients['client-1']
+            sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+            values = {'Client': client.UID(),
+                      'Contact': client.getContacts()[0].UID(),
+                      'SamplingDate': '2015-01-01',
+                      'SampleType': sampletype.UID()}
+            request = {}
+            services = [s.UID() for s in self.services] + [self.calcservice.UID()]
+            ar = create_analysisrequest(client, request, values, services)
+
+            # Set results and interims
+            calcanalysis = None
+            for an in ar.getAnalyses():
+                an = an.getObject()
+                key = an.getKeyword()
+                if key in f['analyses']:
+                    an.setResult(f['analyses'][key])
+                    self.assertEqual(an.getResult(), f['analyses'][key])
+                elif key == self.calcservice.getKeyword():
+                    calcanalysis = an
+
+                # Set interims
+                interims = an.getInterimFields()
+                intermap = []
+                for i in interims:
+                    if i['keyword'] in f['interims']:
+                        ival = float(f['interims'][i['keyword']])
+                        intermap.append({'keyword': i['keyword'],
+                                        'value': ival,
+                                        'title': i['title'],
+                                        'hidden': i['hidden'],
+                                        'type': i['type'],
+                                        'unit': i['unit']})
+                    else:
+                        intermap.append(i)
+                an.setInterimFields(intermap)
+                self.assertEqual(an.getInterimFields(), intermap)
+
+            # Let's go.. check result
+            calcanalysis.calculateResult(True, True)
+            self.assertEqual(calcanalysis.getResult(), f['exresult'])
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestCalculations))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -32,6 +32,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                     {'min': '0.0',  'max': '20.0',   'manual': True}]
         idx = 0
         for s in self.services:
+            s.setDetectionLimitSelector(self.lds[idx]['manual'])
             s.setAllowManualDetectionLimit(self.lds[idx]['manual'])
             s.setLowerDetectionLimit(self.lds[idx]['min'])
             s.setUpperDetectionLimit(self.lds[idx]['max'])
@@ -39,6 +40,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
 
     def tearDown(self):
         for s in self.services:
+            s.setDetectionLimitSelector(False)
             s.setAllowManualDetectionLimit(False)
             s.setLowerDetectionLimit(str(0))
             s.setUpperDetectionLimit(str(1000))

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -28,9 +28,9 @@ class TestLimitDetections(BikaFunctionalTestCase):
         self.services = [servs['analysisservice-3'],
                          servs['analysisservice-6'],
                          servs['analysisservice-7']]
-        self.lds = [{'min': '0.0',  'max': '1000.0', 'manual': False},
-                    {'min': '10.0', 'max': '20.0',   'manual': True},
-                    {'min': '0.0',  'max': '20.0',   'manual': True}]
+        self.lds = [{'min': '0',  'max': '1000', 'manual': False},
+                    {'min': '10', 'max': '20',   'manual': True},
+                    {'min': '0',  'max': '20',   'manual': True}]
         idx = 0
         for s in self.services:
             s.setDetectionLimitSelector(self.lds[idx]['manual'])
@@ -58,7 +58,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '5',
              'expresult'         : 5.0,
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -70,7 +70,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '15',
              'expresult'         : 15.0,
-             'expformattedresult': '15.0',
+             'expformattedresult': '15',
              'isbelowldl'        : False,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -82,7 +82,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '25',
              'expresult'         : 25.0,
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -94,7 +94,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '<5',
              'expresult'         : 5.0, # '<' assignment not allowed
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -106,7 +106,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '<15',
              'expresult'         : 15.0, # '<' assignment not allowed
-             'expformattedresult': '15.0',
+             'expformattedresult': '15',
              'isbelowldl'        : False,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -118,7 +118,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '>15',
              'expresult'         : 15.0, # '>' assignment not allowed
-             'expformattedresult': '15.0',
+             'expformattedresult': '15',
              'isbelowldl'        : False,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -130,7 +130,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '25',
              'expresult'         : 25.0, # '>' assignment not allowed
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -143,7 +143,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '5',
              'expresult'         : 5.0,
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -155,7 +155,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '15',
              'expresult'         : 15.0,
-             'expformattedresult': '15.0',
+             'expformattedresult': '15',
              'isbelowldl'        : False,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -167,7 +167,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '25',
              'expresult'         : 25.0,
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -179,7 +179,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '<5',
              'expresult'         : 10.0, # '<' assignment allowed, but not custom
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : True,
@@ -191,7 +191,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '<15',
              'expresult'         : 10.0, # '<' assignment allowed, but not custom
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : True,
@@ -203,7 +203,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '>15',
              'expresult'         : 20.0, # '>' assignment allowed, but not custom
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -215,7 +215,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : False,
              'input'             : '>25',
              'expresult'         : 20.0, # '>' assignment allowed, but not custom
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -228,7 +228,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '5',
              'expresult'         : 5.0,
-             'expformattedresult': '< 10.0',
+             'expformattedresult': '< 10',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -240,7 +240,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '15',
              'expresult'         : 15.0,
-             'expformattedresult': '15.0',
+             'expformattedresult': '15',
              'isbelowldl'        : False,
              'isaboveudl'        : False,
              'isldl'             : False,
@@ -252,7 +252,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '25',
              'expresult'         : 25.0,
-             'expformattedresult': '> 20.0',
+             'expformattedresult': '> 20',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -264,7 +264,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '<5',
              'expresult'         : 5.0, # '<' assignment allowed
-             'expformattedresult': '< 5.0',
+             'expformattedresult': '< 5',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : True,
@@ -276,7 +276,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '<15',
              'expresult'         : 15.0, # '<' assignment allowed
-             'expformattedresult': '< 15.0',
+             'expformattedresult': '< 15',
              'isbelowldl'        : True,
              'isaboveudl'        : False,
              'isldl'             : True,
@@ -288,7 +288,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '>15',
              'expresult'         : 15.0, # '>' assignment allowed
-             'expformattedresult': '> 15.0',
+             'expformattedresult': '> 15',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -300,7 +300,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
              'manual'            : True,
              'input'             : '>25',
              'expresult'         : 25.0, # '>' assignment allowed
-             'expformattedresult': '> 25.0',
+             'expformattedresult': '> 25',
              'isbelowldl'        : False,
              'isaboveudl'        : True,
              'isldl'             : False,
@@ -337,6 +337,8 @@ class TestLimitDetections(BikaFunctionalTestCase):
             self.assertEqual(an.isLowerDetectionLimit(), case['isldl'])
             self.assertEqual(an.isUpperDetectionLimit(), case['isudl'])
             self.assertEqual(float(an.getResult()), case['expresult'])
+            #import pdb; pdb.set_trace()
+            self.assertEqual(an.getFormattedResult(), case['expformattedresult'])
 
     def test_ar_manageresults_limitdetections(self):
         # Input results
@@ -397,7 +399,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertTrue(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '<')
-                self.assertEqual(an.getFormattedResult(), '< 15.0')
+                self.assertEqual(an.getFormattedResult(), '< 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
@@ -410,7 +412,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertTrue(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '>')
-                self.assertEqual(an.getFormattedResult(), '> 15.0')
+                self.assertEqual(an.getFormattedResult(), '> 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
@@ -425,7 +427,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertTrue(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '<')
-                self.assertEqual(an.getFormattedResult(), '< 15.0')
+                self.assertEqual(an.getFormattedResult(), '< 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
@@ -439,7 +441,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertTrue(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '>')
-                self.assertEqual(an.getFormattedResult(), '> 15.0')
+                self.assertEqual(an.getFormattedResult(), '> 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -6,6 +6,7 @@ from bika.lims.utils.analysisrequest import create_analysisrequest
 from bika.lims.workflow import doActionFor
 from plone.app.testing import login, logout
 from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
 import unittest
 
 try:
@@ -46,6 +47,296 @@ class TestLimitDetections(BikaFunctionalTestCase):
             s.setUpperDetectionLimit(str(1000))
         logout()
         super(TestLimitDetections, self).tearDown()
+
+    def test_ar_manage_results_detectionlimit_selector_manual(self):
+        cases = [
+
+            # ROUND 1 ---------------------
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '5',
+             'expresult'         : 5.0,
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '15',
+             'expresult'         : 15.0,
+             'expformattedresult': '15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '25',
+             'expresult'         : 25.0,
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '<5',
+             'expresult'         : 5.0, # '<' assignment not allowed
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '<15',
+             'expresult'         : 15.0, # '<' assignment not allowed
+             'expformattedresult': '15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '>15',
+             'expresult'         : 15.0, # '>' assignment not allowed
+             'expformattedresult': '15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : False,
+             'manual'            : False,
+             'input'             : '25',
+             'expresult'         : 25.0, # '>' assignment not allowed
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            # ROUND 2 ---------------------
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '5',
+             'expresult'         : 5.0,
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '15',
+             'expresult'         : 15.0,
+             'expformattedresult': '15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '25',
+             'expresult'         : 25.0,
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '<5',
+             'expresult'         : 10.0, # '<' assignment allowed, but not custom
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : True,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '<15',
+             'expresult'         : 10.0, # '<' assignment allowed, but not custom
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : True,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '>15',
+             'expresult'         : 20.0, # '>' assignment allowed, but not custom
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : True},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : False,
+             'input'             : '>25',
+             'expresult'         : 20.0, # '>' assignment allowed, but not custom
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : True},
+
+            # ROUND 3 ---------------------
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '5',
+             'expresult'         : 5.0,
+             'expformattedresult': '< 10.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '15',
+             'expresult'         : 15.0,
+             'expformattedresult': '15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : False,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '25',
+             'expresult'         : 25.0,
+             'expformattedresult': '> 20.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '<5',
+             'expresult'         : 5.0, # '<' assignment allowed
+             'expformattedresult': '< 5.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : True,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '<15',
+             'expresult'         : 15.0, # '<' assignment allowed
+             'expformattedresult': '< 15.0',
+             'isbelowldl'        : True,
+             'isaboveudl'        : False,
+             'isldl'             : True,
+             'isudl'             : False},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '>15',
+             'expresult'         : 15.0, # '>' assignment allowed
+             'expformattedresult': '> 15.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : True},
+
+            {'min'               : '10',
+             'max'               : '20',
+             'displaydl'         : True,
+             'manual'            : True,
+             'input'             : '>25',
+             'expresult'         : 25.0, # '>' assignment allowed
+             'expformattedresult': '> 25.0',
+             'isbelowldl'        : False,
+             'isaboveudl'        : True,
+             'isldl'             : False,
+             'isudl'             : True},
+        ]
+
+        for case in cases:
+            s = self.services[0]
+            s.setDetectionLimitSelector(case['displaydl'])
+            s.setAllowManualDetectionLimit(case['manual'])
+            s.setLowerDetectionLimit(case['min'])
+            s.setUpperDetectionLimit(case['max'])
+
+            # Input results
+            # Client:       Happy Hills
+            # SampleType:   Apple Pulp
+            # Contact:      Rita Mohale
+            # Analyses:     [Calcium, Copper]
+            client = self.portal.clients['client-1']
+            sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+            values = {'Client': client.UID(),
+                      'Contact': client.getContacts()[0].UID(),
+                      'SamplingDate': '2015-01-01',
+                      'SampleType': sampletype.UID()}
+            request = {}
+            ar = create_analysisrequest(client, request, values, [s.UID()])
+            wf = getToolByName(ar, 'portal_workflow')
+            wf.doActionFor(ar, 'receive')
+
+            an = ar.getAnalyses()[0].getObject()
+            an.setResult(case['input'])
+            self.assertEqual(an.isBelowLowerDetectionLimit(), case['isbelowldl'])
+            self.assertEqual(an.isAboveUpperDetectionLimit(), case['isaboveudl'])
+            self.assertEqual(an.isLowerDetectionLimit(), case['isldl'])
+            self.assertEqual(an.isUpperDetectionLimit(), case['isudl'])
+            self.assertEqual(float(an.getResult()), case['expresult'])
 
     def test_ar_manageresults_limitdetections(self):
         # Input results

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -247,7 +247,9 @@ class FormulaValidator:
                         mapping={'keyword': safe_unicode(keyword)})
                 return to_utf8(translate(msg))
 
-        # Wildcards.
+        # Wildcards
+        # LIMS-1769 Allow to use LDL and UDL in calculations
+        # https://jira.bikalabs.com/browse/LIMS-1769
         allowedwds = ['LDL', 'UDL', 'BELOWLDL', 'ABOVEUDL']
         keysandwildcards = re.compile(r"\[([^\]]+)\]").findall(value)
         keysandwildcards = [k for k in keysandwildcards if '.' in k]

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -226,7 +226,6 @@ class FormulaValidator:
     def __call__(self, value, *args, **kwargs):
         if not value:
             return True
-
         instance = kwargs['instance']
         # fieldname = kwargs['field'].getName()
         request = kwargs.get('REQUEST', {})
@@ -237,7 +236,7 @@ class FormulaValidator:
         bsc = getToolByName(instance, 'bika_setup_catalog')
         interim_keywords = interim_fields and \
             [f['keyword'] for f in interim_fields] or []
-        keywords = re.compile(r"\[([^\]]+)\]").findall(value)
+        keywords = re.compile(r"\[([^\.^\]]+)\]").findall(value)
 
         for keyword in keywords:
             # Check if the service keyword exists and is active.
@@ -247,6 +246,25 @@ class FormulaValidator:
                 msg = _("Validation failed: Keyword '${keyword}' is invalid",
                         mapping={'keyword': safe_unicode(keyword)})
                 return to_utf8(translate(msg))
+
+        # Wildcards.
+        allowedwds = ['LDL', 'UDL', 'BELOWLDL', 'ABOVEUDL']
+        keysandwildcards = re.compile(r"\[([^\]]+)\]").findall(value)
+        keysandwildcards = [k for k in keysandwildcards if '.' in k]
+        keysandwildcards = [k.split('.',1) for k in keysandwildcards]
+        errwilds = [k[1] for k in keysandwildcards if k[0] not in keywords]
+        if len(errwilds) > 0:
+            msg = _("Wildcards for interims are not allowed: ${wildcards}",
+                    mapping={'wildcards': safe_unicode(', '.join(errwilds))})
+            return to_utf8(translate(msg))
+
+        wildcards = [k[1] for k in keysandwildcards if k[0] in keywords]
+        wildcards = [wd for wd in wildcards if wd not in allowedwds]
+        if len(wildcards) > 0:
+            msg = _("Invalid wildcards found: ${wildcards}",
+                    mapping={'wildcards': safe_unicode(', '.join(wildcards))})
+            return to_utf8(translate(msg))
+
         return True
 
 validation.register(FormulaValidator())

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,6 @@
 3.1.8 (unreleased)
 ------------------
-LIMS-1768: Allow to use LDL and UDL in calculations.
+LIMS-1769: Allow to use LDL and UDL in calculations.
 LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input
 LIMS-1324: Allow to hide analyses in results reports

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1768: Allow to use LDL and UDL in calculations.
 LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input
 LIMS-1324: Allow to hide analyses in results reports

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1775: Allow to select LDL or UDL defaults in results with readonly mode
 LIMS-1769: Allow to use LDL and UDL in calculations.
 LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input


### PR DESCRIPTION
**Requires PR https://github.com/bikalabs/Bika-LIMS/pull/1500 to be accepted first!!**

With [LIMS-1700](https://jira.bikalabs.com/browse/LIMS-1700), the analyst can input a detection limit manually if the Y/N field "Allow Manual Detection Limit" option is enabled in the 'Analysis Service' view. In some cases, the analyst must be able to set the default Detection Limit (LDL or UDL), but without being able to change it.

Add an additional Y/N "Show Limit Detection selector" field in Analysis Service. The field 'Allow Manual input of LD' will only be available for selection (visible and selectable) if the previous Y/N field is checked.

If "Show Limit Detection Selector" is enabled and "Allow Manual Input of LD" is enabled too, then the behavior will not change: the analyst will be able to select an '>', '<' operand from the selection list and also set the LD manually.

If "Show Limit Detection Selector" is enabled and "Allow Manual Input of LD" is unchecked, the analyst will be able to select an operand from the selection list, but not set the LD manually: the default LD will be displayed in the result field as usuall, but in read-only mode.

If "Show Limit Detection Selector" is disabled, no LD selector will be displayed in the results table.

Functional tests:

```
$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests'
Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.154 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.005 seconds.
  Set up bika.lims.testing.BikaTestLayer in 43.273 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 15 tests with 0 failures and 0 errors in 54.988 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.013 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.050 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.
```