### PR TITLE
LIMS-1634 AR Import fields not importing correctly

### DIFF
--- a/bika/lims/browser/arimports.py
+++ b/bika/lims/browser/arimports.py
@@ -348,7 +348,8 @@ class ClientARImportAddView(BrowserView):
                 aritem = _createObjectByType("ARImportItem", arimport, aritem_id)
                 aritem.edit(
                     SampleName=sample[0],
-                    ClientRef=sample[1],
+                    ClientRef=batch_headers[10],
+                    ClientSid=sample[1],
                     SampleDate=sample[2],
                     SampleType = sample[3],
                     PickingSlip = sample[4],

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1634: AR Import fields (ClientRef, ClientSid) not importing correctly
 LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input
 LIMS-1324: Allow to hide analyses in results reports


### PR DESCRIPTION
The client sample ID gets into the client reference of the ARImportItem and the actual client reference doesn't get imported. The issue is fixed by modifying the assignments while importing the file.


`test_ARImport.robot` ran without failures:

```
Running bika.lims.testing.BikaTestingLayer:Robot tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.243 seconds.
  Set up plone.app.testing.layers.PloneFixture in 7.661 seconds.
  Set up bika.lims.testing.BikaTestLayer in 48.543 seconds.
  Set up plone.testing.z2.ZServer in 0.502 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Running:
    1/1 (100.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'

  Ran 1 tests with 0 failures and 0 errors in 1 minutes 58.983 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Tear down plone.testing.z2.ZServer in 4.929 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.019 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.053 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.006 seconds.
```