### PR TITLE
LIMS-1474 Disposed date is not shown in SampleView

### DIFF
--- a/bika/lims/content/sample.py
+++ b/bika/lims/content/sample.py
@@ -728,6 +728,10 @@ class Sample(BaseFolder, HistoryAwareMixin):
         self.setDateExpired(DateTime())
         self.reindexObject(idxs=["review_state", "getDateExpired", ])
 
+    def workflow_script_dispose(self):
+        self.setDateDisposed(DateTime())
+        self.reindexObject(idxs=["review_state", "getDateDisposed", ])
+
     def workflow_script_sample(self):
         if skip(self, "sample"):
             return

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1474: Disposed date is not shown in Sample View
 LIMS-1700: Lower and Upper Detection Limits (LDL/UDL). Allow manual input
 LIMS-1379: Allow manual uncertainty value input
 LIMS-1324: Allow to hide analyses in results reports


### PR DESCRIPTION
`workflow_script_dispose` is missing in content/sample.py and adding this fixed the issue.

SamplingWorkflow robot tests ran with no failures. The warnings are because my chromedriver is unable to take screenshots.
```
Running bika.lims.testing.BikaTestingLayer:Robot tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.245 seconds.
  Set up plone.app.testing.layers.PloneFixture in 8.325 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 10.401 seconds.
  Set up plone.testing.z2.ZServer in 0.502 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Running:
    1/5 (20.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
The following test left new threads behind:
Sampler login (test_SamplingWorkflow.robot)
New thread(s): [<_DummyThread(Dummy-1, started daemon 140413818812160)>]
    2/5 (40.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
    3/5 (60.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
    4/5 (80.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
    5/5 (100.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'

  Ran 5 tests with 0 failures and 0 errors in 4 minutes 3.308 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Tear down plone.testing.z2.ZServer in 4.775 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.016 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.062 seconds.
  Tear down plone.testing.z2.Startup in 0.008 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.009 seconds.
```

Functional tests:
```
Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.220 seconds.
  Set up plone.app.testing.layers.PloneFixture in 7.892 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 5.656 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:

  Ran 13 tests with 0 failures and 0 errors in 25.841 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.016 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.094 seconds.
  Tear down plone.testing.z2.Startup in 0.007 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.
```