### PR TITLE
LIMS-280 System IDs starting from a specific value

### DIFF
--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -23,21 +23,26 @@ class PrefixesField(RecordsField):
     _properties = RecordsField._properties.copy()
     _properties.update({
         'type' : 'prefixes',
-        'subfields' : ('portal_type', 'prefix', 'separator', 'padding'),
+        'subfields' : ('portal_type', 'prefix', 'separator', 'padding', 'sequence_start'),
         'subfield_labels':{'portal_type': 'Portal type',
                            'prefix': 'Prefix',
                            'separator': 'Prefix Separator',
-                           'padding': 'Padding'
+                           'padding': 'Padding',
+                           'sequence_start': 'Sequence Start',
                            },
         'subfield_readonly':{'portal_type': False,
                              'prefix': False,
                              'padding': False,
-                             'separator': False
+                             'separator': False,
+                             'sequence_start': False,
                             },
         'subfield_sizes':{'portal_type':32,
                           'prefix': 12,
                           'padding':12,
-                          'separator': 5},
+                          'separator': 5,
+                          'sequence_start': 12,
+                          },
+        'subfield_types':{'padding':'int', 'sequence_start': 'int'},
     })
     security = ClassSecurityInfo()
 
@@ -420,17 +425,17 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     PrefixesField('Prefixes',
         schemata = "ID Server",
-        default = [{'portal_type': 'ARImport', 'prefix': 'AI', 'padding': '4', 'separator': '-'},
-                   {'portal_type': 'AnalysisRequest', 'prefix': 'client', 'padding': '0', 'separator': '-'},
-                   {'portal_type': 'Client', 'prefix': 'client', 'padding': '0', 'separator': '-'},
-                   {'portal_type': 'Batch', 'prefix': 'batch', 'padding': '0', 'separator': '-'},
-                   {'portal_type': 'DuplicateAnalysis', 'prefix': 'DA', 'padding': '0', 'separator': '-'},
-                   {'portal_type': 'Invoice', 'prefix': 'I', 'padding': '4', 'separator': '-'},
-                   {'portal_type': 'ReferenceAnalysis', 'prefix': 'RA', 'padding': '4', 'separator': '-'},
-                   {'portal_type': 'ReferenceSample', 'prefix': 'RS', 'padding': '4', 'separator': '-'},
-                   {'portal_type': 'SupplyOrder', 'prefix': 'O', 'padding': '3', 'separator': '-'},
-                   {'portal_type': 'Worksheet', 'prefix': 'WS', 'padding': '4', 'separator': '-'},
-                   {'portal_type': 'Pricelist', 'prefix': 'PL', 'padding': '4', 'separator': '-'},
+        default = [{'portal_type': 'ARImport', 'prefix': 'AI', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'AnalysisRequest', 'prefix': 'client', 'padding': '0', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'Client', 'prefix': 'client', 'padding': '0', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'Batch', 'prefix': 'batch', 'padding': '0', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'DuplicateAnalysis', 'prefix': 'DA', 'padding': '0', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'Invoice', 'prefix': 'I', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'ReferenceAnalysis', 'prefix': 'RA', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'ReferenceSample', 'prefix': 'RS', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'SupplyOrder', 'prefix': 'O', 'padding': '3', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'Worksheet', 'prefix': 'WS', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
+                   {'portal_type': 'Pricelist', 'prefix': 'PL', 'padding': '4', 'separator': '-', 'sequence_start': '0'},
                    ],
 #        fixedSize=8,
         widget=RecordsWidget(
@@ -439,7 +444,10 @@ schema = BikaFolderSchema.copy() + Schema((
                 "Define the prefixes for the unique sequential IDs the system issues for "
                 "objects. In the 'Padding' field, indicate with how many leading zeros the "
                 "numbers must be padded. E.g. a prefix of WS for worksheets with padding of "
-                "4, will see them numbered from WS-0001 to WS-9999. NB: Note that samples "
+                "4, will see them numbered from WS-0001 to WS-9999. Sequence Start "
+                "indicates the number from which the next ID should start. This is "
+                "set only if it is greater than existing id numbers. Note that the "
+                "gap created by jumping IDs cannot be refilled. NB: Note that samples "
                 "and analysis requests are prefixed with sample type abbreviations and are "
                 "not configured in this table - their padding can be set in the specified "
                 "fields below"),
@@ -461,6 +469,19 @@ schema = BikaFolderSchema.copy() + Schema((
         widget = IntegerWidget(
             label=_("Sample ID Padding"),
             description=_("The length of the zero-padding for Sample IDs"),
+        )
+    ),
+    IntegerField('SampleIDSequenceStart',
+        schemata = "ID Server",
+        required = 1,
+        default = 0,
+        widget = IntegerWidget(
+            label=_("Sample ID Sequence Start"),
+            description=_(
+                "The number from which the next id should start. This "
+                "is set only if it is greater than existing id numbers. "
+                "Note that the resultant gap between IDs cannot be filled."
+                ),
         )
     ),
     IntegerField('ARIDPadding',

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -156,14 +156,23 @@ def generateUniqueId(context):
                 # Special case for Sample IDs
                 prefix = fn_normalize(context.getSampleType().getPrefix())
                 padding = context.bika_setup.getSampleIDPadding()
+                sequence_start = context.bika_setup.getSampleIDSequenceStart()
                 new_id = next_id(prefix+year)
+                # If sequence_start is greater than new_id. Set
+                # sequence_start as new_id. (Jira LIMS-280)
+                if sequence_start > int(new_id):
+                    new_id = str(sequence_start)
                 if padding:
                     new_id = new_id.zfill(int(padding))
                 return ('%s%s' + separator + '%s') % (prefix, year, new_id)
             elif d['portal_type'] == context.portal_type:
                 prefix = d['prefix']
                 padding = d['padding']
+                sequence_start = d.get("sequence_start", None)
                 new_id = next_id(prefix+year)
+                # Jira-tracker LIMS-280
+                if sequence_start and sequence_start > int(new_id):
+                    new_id = str(sequence_start)
                 if padding:
                     new_id = new_id.zfill(int(padding))
                 return ('%s%s' + separator + '%s') % (prefix, year, new_id)


### PR DESCRIPTION
The specific value can be configured using Sequence Start in Bika Setup. The sequence_start applies only if it is greater than existing IDs. Sample is treated as special case with new setup field called SampleIDSequenceStart. In bika setup, types of padding and sequence_start are made 'int' to provide validation.

Adding samples, ARImports, batches, clients and worksheets has been thoroughly tested manually (with and without) specifying sequence_start.