### PR TITLE
Relocate ProtocolID and CommercialID fields from AS to default schemata

### DIFF
--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -896,6 +896,7 @@ schema = BikaSchema.copy() + Schema((
     ),
     StringField('CommercialID',
         searchable=1,
+        schemata='Description',
         required=0,
         widget=StringWidget(
             label=_("Commercial ID"),
@@ -904,7 +905,7 @@ schema = BikaSchema.copy() + Schema((
     ),
     StringField('ProtocolID',
         searchable=1,
-        schemata = 'Insurance',
+        schemata = 'Description',
         required=0,
         widget=StringWidget(
             label=_("Protocol ID"),


### PR DESCRIPTION
This prevents the anoying selection list in the edit view when more than 6 schematas.