### PR TITLE
LIMS-1808 Uncertainty calculation on DL

### DIFF
--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -364,8 +364,8 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
                 analysis.setUncertainty(uncertainties[uid])
 
             # Need to save the detection limit?
-            if analysis_active and uid in dlimits and dlimits[uid]:
-                analysis.setDetectionLimitOperand(dlimits[uid])
+            if analysis_active:
+                analysis.setDetectionLimitOperand(dlimits.get(uid, None))
 
             if uid not in results or not results[uid]:
                 continue

--- a/bika/lims/browser/js/bika.lims.utils.calcs.js
+++ b/bika/lims/browser/js/bika.lims.utils.calcs.js
@@ -65,7 +65,19 @@ function CalculationUtils() {
                  * results with readonly mode
                  * https://jira.bikalabs.com/browse/LIMS-1775
                  */
-                var andls = $.parseJSON($(tr).find('input[id^="AnalysisDLS."]').val());
+                var defandls = {
+                                default_ldl: 0,
+                                default_udl: 100000,
+                                dlselect_allowed:  false,
+                                manual_allowed: false,
+                                is_ldl: false,
+                                is_udl: false,
+                                below_ldl: false,
+                                above_udl: false
+                            };
+                var andls = $(tr).find('input[id^="AnalysisDLS."]');
+                andls = andls.length > 0 ? andls.first().val() : null;
+                andls = andls != null ? $.parseJSON(andls) : defandls;
                 var dlop = $(tr).find('select[name^="DetectionLimit."]');
                 if (dlop.length > 0) {
                     // If the analysis is under edition, give priority to
@@ -86,7 +98,7 @@ function CalculationUtils() {
                                 andls.is_ldl = tryldl;
                                 andls.is_udl = tryudl;
                                 andls.below_ldl = tryldl;
-                                andls.above_ldl = tryudl;
+                                andls.above_udl = tryudl;
                             } else {
                                 // Unexpected case or Indeterminate result.
                                 // Although the selection of DL is allowed (DL
@@ -133,6 +145,8 @@ function CalculationUtils() {
                 var mapping = {
                                 keyword:  $(e).attr('objectid'),
                                 result:   result,
+                                isldl:    andls.is_ldl,
+                                isudl:    andls.is_udl,
                                 ldl:      andls.is_ldl ? result : andls.default_ldl,
                                 udl:      andls.is_udl ? result : andls.default_udl,
                                 belowldl: andls.below_ldl,

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -275,15 +275,34 @@ function WorksheetManageResultsView() {
         $('select[name^="DetectionLimit."]').change(function() {
             var defdls = $(this).closest('td').find('input[id^="DefaultDLS."]').first().val();
             var resfld = $(this).closest('tr').find('input[name^="Result."]')[0];
+            var uncfld = $(this).closest('tr').find('input[name^="Uncertainty."]');
             defdls = $.parseJSON(defdls);
             $(resfld).prop('readonly', !defdls.manual);
             if ($(this).val() == '<') {
                 $(resfld).val(defdls['min']);
+                // Inactivate uncertainty?
+                if (uncfld.length > 0) {
+                    $(uncfld).val('');
+                    $(uncfld).prop('readonly', true);
+                    $(uncfld).closest('td').children().hide();
+                }
             } else if ($(this).val() == '>') {
                 $(resfld).val(defdls['max']);
+                // Inactivate uncertainty?
+                if (uncfld.length > 0) {
+                    $(uncfld).val('');
+                    $(uncfld).prop('readonly', true);
+                    $(uncfld).closest('td').children().hide();
+                }
             } else {
                 $(resfld).val('');
                 $(resfld).prop('readonly',false);
+                // Activate uncertainty?
+                if (uncfld.length > 0) {
+                    $(uncfld).val('');
+                    $(uncfld).prop('readonly', false);
+                    $(uncfld).closest('td').children().show();
+                }
             }
             // Maybe the result is used in calculations...
             $(resfld).change();

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -488,7 +488,7 @@ class Analysis(BaseContent):
         # https://jira.bikalabs.com/browse/LIMS-1808
         if self.isAboveUpperDetectionLimit() or \
            self.isBelowLowerDetectionLimit():
-            self.Schema().getField('Uncertainty').set(self, '0')
+            self.Schema().getField('Uncertainty').set(self, None)
 
     def setUncertainty(self, unc):
         """ Sets the uncertainty for this analysis. If the result is
@@ -499,7 +499,7 @@ class Analysis(BaseContent):
         # https://jira.bikalabs.com/browse/LIMS-1808
         if self.isAboveUpperDetectionLimit() or \
            self.isBelowLowerDetectionLimit():
-            self.Schema().getField('Uncertainty').set(self, '0')
+            self.Schema().getField('Uncertainty').set(self, None)
         else:
             self.Schema().getField('Uncertainty').set(self, unc)
 

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -833,8 +833,7 @@ class Analysis(BaseContent):
         dl = self.getDetectionLimitOperand()
         if dl:
             try:
-                result = float(result) # required, check if floatable
-                result = format_numeric_result(self, result, sciformat=sciformat)
+                res = float(result) # required, check if floatable
                 return formatDecimalMark('%s %s' % (dl, result), decimalmark)
             except:
                 logger.warn("The result for the analysis %s is a "

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -118,7 +118,7 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
 
     objres = None
     try:
-        objres = float(result)
+        objres = float(analysis.getResult())
     except ValueError:
         pass
 

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -119,7 +119,7 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
     service = analysis.getService()
     uncertainty = analysis.getUncertainty(result)
 
-    if uncertainty is None:
+    if uncertainty is None or uncertainty == 0:
         return ""
 
     # Scientific notation?

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -116,8 +116,19 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
     except ValueError:
         return ""
 
+    objres = None
+    try:
+        objres = float(result)
+    except ValueError:
+        pass
+
     service = analysis.getService()
-    uncertainty = analysis.getUncertainty(result)
+    uncertainty = None
+    if result == objres:
+        # To avoid problems with DLs
+        uncertainty = analysis.getUncertainty()
+    else:
+        uncertainty = analysis.getUncertainty(result)
 
     if uncertainty is None or uncertainty == 0:
         return ""

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1808: Uncertainty calculation on DL
 LIMS-1522: Site Error adding display columns to sorted AR list
 LIMS-1705: Invoices. Currency unit overcooked
 LIMS-1806: Instrument Interface. AQ2. Seal Analytical


### PR DESCRIPTION
For DL results, the system must not calculate the uncertainty, but leave it empty.

```
$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests'
Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.151 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.841 seconds.
  Set up bika.lims.testing.BikaTestLayer in 43.733 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 15 tests with 0 failures and 0 errors in 54.967 seconds.
Running bika.lims.testing.SimpleTestingLayer:Functional tests:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.012 seconds.
  Set up bika.lims.testing.SimpleTestLayer in 8.143 seconds.
  Set up bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 1 tests with 0 failures and 0 errors in 2.728 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.SimpleTestLayer in 0.007 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.047 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.006 seconds.

Total: 16 tests, 0 failures, 0 errors in 1 minutes 56.294 seconds.
```