### PR TITLE
LIMS-1697 Error updating bika.lims 317 to 318 via quickinstaller

### DIFF
--- a/bika/lims/upgrade/__init__.py
+++ b/bika/lims/upgrade/__init__.py
@@ -39,4 +39,4 @@ def skip_pre315(portal):
     info = qi.upgradeInfo('bika.lims')
     if info['installedVersion'] > '315':
         return True
-
+    return False

--- a/bika/lims/upgrade/__init__.py
+++ b/bika/lims/upgrade/__init__.py
@@ -29,3 +29,14 @@ def stub(module_path, class_name, base_class, meta_class=type):
     module = create_modules(module_path)
     cls = meta_class(class_name, (base_class, ), {})
     setattr(module, class_name, cls)
+
+
+def skip_pre315(portal):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    qi = portal.portal_quickinstaller
+    info = qi.upgradeInfo('bika.lims')
+    if info['installedVersion'] > '315':
+        return True
+

--- a/bika/lims/upgrade/to1010.py
+++ b/bika/lims/upgrade/to1010.py
@@ -13,6 +13,13 @@ from Products.CMFCore.utils import getToolByName
 def addBatches(tool):
     """
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     portal_catalog = getToolByName(portal, 'portal_catalog')
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to1100.py
+++ b/bika/lims/upgrade/to1100.py
@@ -13,6 +13,13 @@ from Products.CMFCore.utils import getToolByName
 def upgrade(tool):
     """
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     portal_catalog = getToolByName(portal, 'portal_catalog')
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to1101.py
+++ b/bika/lims/upgrade/to1101.py
@@ -14,6 +14,12 @@ def upgrade(tool):
     """
     issue #615: missing configuration for some add permissions
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
 

--- a/bika/lims/upgrade/to1102.py
+++ b/bika/lims/upgrade/to1102.py
@@ -17,6 +17,12 @@ def upgrade(tool):
     """
     issue #623, #583, ...
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3000.py
+++ b/bika/lims/upgrade/to3000.py
@@ -8,6 +8,13 @@ from bika.lims.setuphandlers import BikaGenerator
 from bika.lims import logger
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     at = getToolByName(portal, 'archetype_tool')
@@ -73,7 +80,7 @@ def upgrade(tool):
         bc.delIndex('getSamplePointTitle')
     bc.addIndex('getSampleTypeTitle', 'KeywordIndex')
     bc.addIndex('getSamplePointTitle', 'KeywordIndex')
-    
+
     if 'getClientSampleID' not in pc.indexes():
         pc.addIndex('getClientSampleID', 'FieldIndex')
         pc.addColumn('getClientSampleID')

--- a/bika/lims/upgrade/to3001.py
+++ b/bika/lims/upgrade/to3001.py
@@ -5,6 +5,13 @@ from Products.CMFCore.utils import getToolByName
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3002.py
+++ b/bika/lims/upgrade/to3002.py
@@ -6,6 +6,13 @@ from bika.lims.permissions import AddAttachment
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3003.py
+++ b/bika/lims/upgrade/to3003.py
@@ -5,6 +5,13 @@ from Products.CMFCore.utils import getToolByName
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3004.py
+++ b/bika/lims/upgrade/to3004.py
@@ -5,6 +5,13 @@ from Acquisition import aq_parent
 def upgrade(tool):
     """ Re-import types tool to add condition for sample/partitions view
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3005.py
+++ b/bika/lims/upgrade/to3005.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """Added D3.js library and D3 Control-chart for Instrument QC
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3006.py
+++ b/bika/lims/upgrade/to3006.py
@@ -4,6 +4,13 @@ from bika.lims.permissions import *
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     """Simple imports for missing PricelistFolder view
     mimics bika2 behaviour faithfully
     """

--- a/bika/lims/upgrade/to3007.py
+++ b/bika/lims/upgrade/to3007.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """Added bika.lims.loader.js and bika.lims.method.edit.js
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3008.py
+++ b/bika/lims/upgrade/to3008.py
@@ -6,6 +6,12 @@ from Products.Archetypes.config import REFERENCE_CATALOG
 def upgrade(tool):
     """Added bika.lims.analysisservice.edit.js
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3009.py
+++ b/bika/lims/upgrade/to3009.py
@@ -6,6 +6,12 @@ from Products.Archetypes.config import REFERENCE_CATALOG
 def upgrade(tool):
     """Added bika.lims.instrumentcalibration.edit.js
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3010.py
+++ b/bika/lims/upgrade/to3010.py
@@ -7,6 +7,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to3011.py
+++ b/bika/lims/upgrade/to3011.py
@@ -7,6 +7,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to3012.py
+++ b/bika/lims/upgrade/to3012.py
@@ -7,6 +7,13 @@ def upgrade(tool):
     """ Remove Maintenance, Validations, Calibrations ans Schedule
         https://github.com/bikalabs/Bika-LIMS/issues/1134
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3013.py
+++ b/bika/lims/upgrade/to3013.py
@@ -6,6 +6,13 @@ from bika.lims.upgrade import stub
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3014.py
+++ b/bika/lims/upgrade/to3014.py
@@ -4,6 +4,13 @@ from bika.lims.permissions import *
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     # missing /supplyorders folder permission

--- a/bika/lims/upgrade/to3015.py
+++ b/bika/lims/upgrade/to3015.py
@@ -6,6 +6,13 @@ from bika.lims.upgrade import stub
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3016.py
+++ b/bika/lims/upgrade/to3016.py
@@ -7,6 +7,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to3017.py
+++ b/bika/lims/upgrade/to3017.py
@@ -7,6 +7,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     typestool = getToolByName(portal, 'portal_types')

--- a/bika/lims/upgrade/to3018.py
+++ b/bika/lims/upgrade/to3018.py
@@ -8,6 +8,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     typestool = getToolByName(portal, 'portal_types')
@@ -17,7 +24,7 @@ def upgrade(tool):
         portal.bika_setup.manage_delObjects('bika_arpriorities')
     except BadRequest:
         logger.info("Folder doesn't exist")
-        
+
     try:
         typestool.constructContent(type_name="ARPriorities",
                                container=portal.bika_setup,

--- a/bika/lims/upgrade/to3019.py
+++ b/bika/lims/upgrade/to3019.py
@@ -4,6 +4,13 @@ from bika.lims.permissions import *
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     wf = portal.portal_workflow
@@ -14,7 +21,7 @@ def upgrade(tool):
     # missing bika_arpriorities folder permission
     folder = portal.bika_setup.bika_arpriorities
     folder.manage_permission(
-            ManageARPriority, 
+            ManageARPriority,
             ['Manager', 'Site Administrator', 'LabManager', 'Owner'], 0)
     folder.reindexObject()
 

--- a/bika/lims/upgrade/to3020.py
+++ b/bika/lims/upgrade/to3020.py
@@ -8,6 +8,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     portal_catalog = getToolByName(portal, 'portal_catalog')
 

--- a/bika/lims/upgrade/to3021.py
+++ b/bika/lims/upgrade/to3021.py
@@ -8,6 +8,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     at = getToolByName(portal, 'archetype_tool')
     at.setCatalogsByType('ARPriority', ['bika_setup_catalog', ])

--- a/bika/lims/upgrade/to3022.py
+++ b/bika/lims/upgrade/to3022.py
@@ -9,6 +9,12 @@ def upgrade(tool):
         Instruments to a Worksheet is no longer used. The assignment
         is performed to each Analysis directly
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3023.py
+++ b/bika/lims/upgrade/to3023.py
@@ -7,6 +7,13 @@ from bika.lims.permissions import AddStorageLocation
 def upgrade(tool):
     """ Add Storage locacations to ARs and Samples.
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3024.py
+++ b/bika/lims/upgrade/to3024.py
@@ -7,6 +7,13 @@ from bika.lims.permissions import AddStorageLocation
 def upgrade(tool):
     """ Add Storage locacations to ARs and Samples.
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3025.py
+++ b/bika/lims/upgrade/to3025.py
@@ -5,6 +5,13 @@ from Products.CMFCore.utils import getToolByName
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3026.py
+++ b/bika/lims/upgrade/to3026.py
@@ -3,6 +3,13 @@ from Acquisition import aq_parent
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3027.py
+++ b/bika/lims/upgrade/to3027.py
@@ -3,6 +3,13 @@ from Acquisition import aq_parent
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     portal.portal_actions.portal_tabs.queries.visible = False

--- a/bika/lims/upgrade/to3028.py
+++ b/bika/lims/upgrade/to3028.py
@@ -4,6 +4,13 @@ from Products.CMFCore.utils import getToolByName
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     for pricelist in portal.pricelists.objectValues('Pricelist'):

--- a/bika/lims/upgrade/to3029.py
+++ b/bika/lims/upgrade/to3029.py
@@ -5,6 +5,13 @@ from Products.CMFCore import permissions
 from Products.CMFCore.utils import getToolByName
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3030.py
+++ b/bika/lims/upgrade/to3030.py
@@ -7,6 +7,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     workflow = getToolByName(portal, "portal_workflow")

--- a/bika/lims/upgrade/to3031.py
+++ b/bika/lims/upgrade/to3031.py
@@ -5,6 +5,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     at = getToolByName(portal, 'archetype_tool')
     at.setCatalogsByType('SubGroup', ['bika_setup_catalog', ])

--- a/bika/lims/upgrade/to3032.py
+++ b/bika/lims/upgrade/to3032.py
@@ -5,6 +5,13 @@ from zExceptions import BadRequest
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     setup.runImportStepFromProfile(

--- a/bika/lims/upgrade/to3033.py
+++ b/bika/lims/upgrade/to3033.py
@@ -2,6 +2,13 @@ from Acquisition import aq_parent, aq_inner
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     setup.runImportStepFromProfile(

--- a/bika/lims/upgrade/to3034.py
+++ b/bika/lims/upgrade/to3034.py
@@ -2,6 +2,13 @@ from Acquisition import aq_parent, aq_inner
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     # Fix Analysis Services IMM incoherences

--- a/bika/lims/upgrade/to3035.py
+++ b/bika/lims/upgrade/to3035.py
@@ -2,6 +2,13 @@ from Acquisition import aq_parent, aq_inner
 from Products.CMFCore.utils import getToolByName
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     # Fix Pricelists - VATTotal was renamed to VATAmount

--- a/bika/lims/upgrade/to3036.py
+++ b/bika/lims/upgrade/to3036.py
@@ -3,6 +3,13 @@ from Products.CMFCore.utils import getToolByName
 from bika.lims.permissions import ManageWorksheets
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3037.py
+++ b/bika/lims/upgrade/to3037.py
@@ -5,6 +5,13 @@ from Products.CMFCore.utils import getToolByName
 def upgrade(tool):
     """ Refactor ARs listing to allow sorting by priority
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
 
     def addIndex(cat, *args):
         try:

--- a/bika/lims/upgrade/to3038.py
+++ b/bika/lims/upgrade/to3038.py
@@ -4,6 +4,13 @@ from Products.CMFCore.utils import getToolByName
 
 
 def upgrade(tool):
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3039.py
+++ b/bika/lims/upgrade/to3039.py
@@ -6,6 +6,13 @@ from Products.CMFCore import permissions
 def upgrade(tool):
     """LIMS-1275 - Remove acquisition for "Modify portal content" permission
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
 
     # /bika_setup -

--- a/bika/lims/upgrade/to3040.py
+++ b/bika/lims/upgrade/to3040.py
@@ -6,6 +6,13 @@ from Products.CMFCore.utils import getToolByName
 def upgrade(tool):
     """LIMS-1059: Worksheet rejection workflow
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 

--- a/bika/lims/upgrade/to3041.py
+++ b/bika/lims/upgrade/to3041.py
@@ -7,6 +7,12 @@ def upgrade(tool):
     """Added bika.lims.loader.js and bika.lims.artemplate.edit.js
     Also fix LIMS-1352 (would have been 3042, but metadata.xml is not up to date!).
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3042.py
+++ b/bika/lims/upgrade/to3042.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """Added bika.lims.client.view.js
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3043.py
+++ b/bika/lims/upgrade/to3043.py
@@ -9,6 +9,12 @@ def upgrade(tool):
         bika.lims.referencesample.js
         bika.lims.graphics.css
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3044.py
+++ b/bika/lims/upgrade/to3044.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """ JS structure refactoring
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3045.py
+++ b/bika/lims/upgrade/to3045.py
@@ -6,6 +6,12 @@ from Products.CMFCore.utils import getToolByName
 def upgrade(tool):
     """ Fix workflow variable review_history permission guard.
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     wf_ids = [
         'bika_analysis_workflow',

--- a/bika/lims/upgrade/to3046.py
+++ b/bika/lims/upgrade/to3046.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """Added missing bika.lims.sandbox.ar_analyses.js
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3047.py
+++ b/bika/lims/upgrade/to3047.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """AJS changes
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3048.py
+++ b/bika/lims/upgrade/to3048.py
@@ -6,6 +6,12 @@ from bika.lims.permissions import *
 def upgrade(tool):
     """AJS changes
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
 
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup

--- a/bika/lims/upgrade/to3049.py
+++ b/bika/lims/upgrade/to3049.py
@@ -8,6 +8,14 @@ from bika.lims import logger
 def upgrade(tool):
     """ Sort by Type in instruments
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
+
     portal = aq_parent(aq_inner(tool))
     bsc = getToolByName(portal, 'bika_setup_catalog', None)
 

--- a/bika/lims/upgrade/to3050.py
+++ b/bika/lims/upgrade/to3050.py
@@ -6,6 +6,13 @@ from Products.CMFCore.utils import getToolByName
 def upgrade(tool):
     """ Convert analysis specs to AR specs in AR.ResultsRange.
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     bc = getToolByName(portal, 'bika_catalog', None)
     bsc = getToolByName(portal, 'bika_setup_catalog', None)

--- a/bika/lims/upgrade/to3051.py
+++ b/bika/lims/upgrade/to3051.py
@@ -8,6 +8,13 @@ from bika.lims import logger
 def upgrade(tool):
     """ Adding getRawSamplePoint/Type idx to obtain Sample's uid easly
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     bsc = getToolByName(portal, 'bika_setup_catalog', None)
 

--- a/bika/lims/upgrade/to3052.py
+++ b/bika/lims/upgrade/to3052.py
@@ -8,11 +8,18 @@ from bika.lims import logger
 def upgrade(tool):
     """  stickers
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
 
     setup.runImportStepFromProfile('profile-bika.lims:default', 'typeinfo')
-    
+
     prt = portal.bika_setup.AutoPrintLabels
     portal.bika_setup.setAutoPrintStickers(prt)
 

--- a/bika/lims/upgrade/to3053.py
+++ b/bika/lims/upgrade/to3053.py
@@ -10,6 +10,13 @@ def upgrade(tool):
     set the default, but all new sites will have the 'properties.xml' loaded,
     which does set the default.
     """
+    # Hack prevent out-of-date upgrading
+    # Related: PR #1484
+    # https://github.com/bikalabs/Bika-LIMS/pull/1484
+    from bika.lims.upgrade import skip_pre315
+    if skip_pre315(aq_parent(aq_inner(tool))):
+        return True
+
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
     setup.runImportStepFromProfile('profile-bika.lims:default', 'typeinfo')

--- a/bika/lims/upgrade/to317.py
+++ b/bika/lims/upgrade/to317.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from Products.Archetypes.BaseContent import BaseContent
 from bika.lims.upgrade import stub
+from bika.lims import logger
 
 
 def LIMS1519(portal):
@@ -26,6 +27,9 @@ def upgrade(tool):
     """
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
+    qi = portal.portal_quickinstaller
+    ufrom = qi.upgradeInfo('bika.lims')['installedVersion']
+    logger.info("Upgrading Bika LIMS: %s -> %s" % (ufrom, '317'))
 
     # Updated profile steps
 

--- a/bika/lims/upgrade/to318.py
+++ b/bika/lims/upgrade/to318.py
@@ -2,13 +2,16 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from Products.Archetypes.BaseContent import BaseContent
 from bika.lims.upgrade import stub
-
+from bika.lims import logger
 
 def upgrade(tool):
     """Upgrade step required for Bika LIMS 3.1.8
     """
     portal = aq_parent(aq_inner(tool))
     setup = portal.portal_setup
+    qi = portal.portal_quickinstaller
+    ufrom = qi.upgradeInfo('bika.lims')['installedVersion']
+    logger.info("Upgrading Bika LIMS: %s -> %s" % (ufrom, '318'))
 
     # Reread typeinfo to update/add the modified/added types
     setup.runImportStepFromProfile('profile-bika.lims:default', 'typeinfo')

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8 (unreleased)
 ------------------
+LIMS-1697: Error updating bika.lims 317 to 318 via quickinstaller
 LIMS-1820: QC Graphs DateTime's X-Axis not well sorted
 LIMS-280 : System IDs starting from a specific value
 LIMS-1819: Bika LIMS in footer, not Bika Lab Systems


### PR DESCRIPTION
Yes... I know a massive and ugly hack, but fix the upgrade issues rised because of the chestnut `source="*"` mentioned here: https://github.com/bikalabs/Bika-LIMS/pull/1484