### PR TITLE
Drop trailing zeros from decimal on DLs

### DIFF
--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -34,6 +34,7 @@ from bika.lims.interfaces import IAnalysis, IDuplicateAnalysis, IReferenceAnalys
     IRoutineAnalysis
 from bika.lims.interfaces import IReferenceSample
 from bika.lims.utils import changeWorkflowState, formatDecimalMark
+from bika.lims.utils import drop_trailing_zeros_decimal
 from bika.lims.utils.analysis import get_significant_digits
 from bika.lims.workflow import skip
 from bika.lims.workflow import doActionFor
@@ -834,7 +835,8 @@ class Analysis(BaseContent):
         if dl:
             try:
                 res = float(result) # required, check if floatable
-                return formatDecimalMark('%s %s' % (dl, result), decimalmark)
+                res = drop_trailing_zeros_decimal(res)
+                return formatDecimalMark('%s %s' % (dl, res), decimalmark)
             except:
                 logger.warn("The result for the analysis %s is a "
                             "detection limit, but not floatable: %s" %
@@ -885,12 +887,18 @@ class Analysis(BaseContent):
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()
         if result < ldl:
-            return formatDecimalMark('< %s' % format_numeric_result(self, ldl, sciformat=sciformat), decimalmark)
+            # LDL must not be formatted according to precision, etc.
+            # Drop trailing zeros from decimal
+            ldl = drop_trailing_zeros_decimal(ldl)
+            return formatDecimalMark('< %s' % ldl, decimalmark)
 
         # Above Upper Detection Limit (UDL)?
         udl = self.getUpperDetectionLimit()
         if result > udl:
-            return formatDecimalMark('> %s' % format_numeric_result(self, udl, sciformat=sciformat), decimalmark)
+            # UDL must not be formatted according to precision, etc.
+            # Drop trailing zeros from decimal
+            udl = drop_trailing_zeros_decimal(udl)
+            return formatDecimalMark('> %s' % udl, decimalmark)
 
         # Render numerical values
         return formatDecimalMark(format_numeric_result(self, result, sciformat=sciformat), decimalmark=decimalmark)

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -523,3 +523,10 @@ def format_supsub(text):
         out.append(subsup.pop())
 
     return ''.join(out)
+
+def drop_trailing_zeros_decimal(num):
+    """ Drops the trailinz zeros from decimal value.
+        Returns a string
+    """
+    out = str(num)
+    return out.rstrip('0').rstrip('.') if '.' in out else out


### PR DESCRIPTION
2 tests from TestDetectionLimit suite was failing. Excerpt from http://pastie.org/10211761
```
Failure in test test_ar_manage_results_detectionlimit_selector_manual (bika.lims.tests.test_limitdetections.TestLimitDetections)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/campbell/workspace/bika.lims/buildout/src/bika.lims/bika/lims/tests/test_limitdetections.py", line 341, in test_ar_manage_results_detectionlimit_selector_manual
    self.assertEqual(an.getFormattedResult(), case['expformattedresult'])
  File "/usr/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: '< 10.0' != '< 10'

    20/28 (71.4%)

Failure in test test_ar_manageresults_limitdetections (bika.lims.tests.test_limitdetections.TestLimitDetections)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/campbell/workspace/bika.lims/buildout/src/bika.lims/bika/lims/tests/test_limitdetections.py", line 402, in test_ar_manageresults_limitdetections
    self.assertEqual(an.getFormattedResult(), '< 15')
  File "/usr/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: '< 15.0' != '< 15'
```
Now, fixed:

```
$ bin/test -s bika.lims -t TestLimitDetections
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.151 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.130 seconds.
  Set up bika.lims.testing.BikaTestLayer in 43.378 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                
  Ran 2 tests with 0 failures and 0 errors in 23.725 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.011 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.048 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.
```


@Espurna you need to check yours (TestInstrumentAlerts suite):

```
$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests'
Test-module import failures:

Module: bika.lims.tests.test_doctests

TypeError: Module bika.lims.tests.test_doctests does not define any tests


Module: bika.lims.tests.test_robot

TypeError: Module bika.lims.tests.test_robot does not define any tests


Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.149 seconds.
  Set up plone.app.testing.layers.PloneFixture in 4.877 seconds.
  Set up bika.lims.testing.BikaTestLayer in 42.983 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
    6/17 (35.3%) test_instrument_calibration (...truments.TestInstrumentAlerts)

Failure in test test_instrument_calibration (bika.lims.tests.test_instruments.TestInstrumentAlerts)
Traceback (most recent call last):
  File "/home/jordi/dev/xispa/bikalims/Python-2.7/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/home/jordi/dev/xispa/bikalims/zinstance/src/bika.lims/bika/lims/tests/test_instruments.py", line 91, in test_instrument_calibration
    self.assertTrue(instrument.isCalibrationInProgress())
  File "/home/jordi/dev/xispa/bikalims/Python-2.7/lib/python2.7/unittest/case.py", line 424, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true

    7/17 (41.2%) test_instrument_validation (...struments.TestInstrumentAlerts)

Failure in test test_instrument_validation (bika.lims.tests.test_instruments.TestInstrumentAlerts)
Traceback (most recent call last):
  File "/home/jordi/dev/xispa/bikalims/Python-2.7/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/home/jordi/dev/xispa/bikalims/zinstance/src/bika.lims/bika/lims/tests/test_instruments.py", line 51, in test_instrument_validation
    self.assertTrue(instrument.isValidationInProgress())
  File "/home/jordi/dev/xispa/bikalims/Python-2.7/lib/python2.7/unittest/case.py", line 424, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true

                                                                               
  Ran 17 tests with 2 failures and 0 errors in 57.261 seconds.
Running bika.lims.testing.SimpleTestingLayer:Functional tests:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.012 seconds.
  Set up bika.lims.testing.SimpleTestLayer in 6.805 seconds.
  Set up bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 1 tests with 0 failures and 0 errors in 2.748 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.SimpleTestLayer in 0.007 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.051 seconds.
  Tear down plone.testing.z2.Startup in 0.008 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.005 seconds.

Test-modules with import problems:
  bika.lims.tests.test_doctests
  bika.lims.tests.test_robot

Tests with failures:
   test_instrument_calibration (bika.lims.tests.test_instruments.TestInstrumentAlerts)
   test_instrument_validation (bika.lims.tests.test_instruments.TestInstrumentAlerts)
Total: 18 tests, 2 failures, 0 errors in 1 minutes 55.584 seconds.
```