### PR TITLE
Curate/3.1.8

### DIFF
--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -334,8 +334,12 @@ class ajaxCalculateAnalysisEntry(BrowserView):
             anvals = self.current_results[uid]
             isldl = anvals.get('isldl', False)
             isudl = anvals.get('isudl', False)
-            belowldl = (isldl or flres < float(anvals.get('ldl',0)))
-            aboveudl = (isudl or flres > float(anvals.get('udl',10000000)))
+            ldl = anvals.get('ldl',0)
+            udl = anvals.get('udl',0)
+            ldl = float(ldl) if isnumber(ldl) else 0
+            udl = float(udl) if isnumber(udl) else 10000000
+            belowldl = (isldl or flres < ldl)
+            aboveudl = (isudl or flres > udl)
             unc = '' if (belowldl or aboveudl) else analysis.getUncertainty(Result.get('result'))
             if not (belowldl or aboveudl):
                 self.uncertainties.append({'uid': uid, 'uncertainty': unc})

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -199,7 +199,9 @@ function AnalysisRequestAddView() {
 				var form_rr = $.parseJSON($(element).val());
                 // If The Analysis Specification doesn't have results range, the form_rr[column]
                 // should be a void dictionary
-                if (data.objects[0]['ResultsRange'].length == 0) {
+                if (data.objects.length != 1 ||
+                    !('ResultsRange' in data.objects[0]) ||
+                    data.objects[0]['ResultsRange'].length == 0) {
                     form_rr[column] = {};
                 }
                 else {

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,4 +1,4 @@
-3.1.8 (2015-05-29)
+3.1.8 (2015-06-03)
 ------------------
 LIMS-1773: Instrument. Thermo Fisher ELISA Spectrophotometer
 LIMS-1697: Error updating bika.lims 317 to 318 via quickinstaller


### PR DESCRIPTION
```
$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests'
Removing stale bytecode file /home/jordi/dev/xispa/bikalims/zinstance/src/bika.lims/bika/lims/browser/analysisprofile.pyc
Removing stale bytecode file /home/jordi/dev/xispa/bikalims/zinstance/src/bika.lims/bika/lims/browser/artemplate.pyc
Test-module import failures:

Module: bika.lims.tests.test_doctests

TypeError: Module bika.lims.tests.test_doctests does not define any tests


Module: bika.lims.tests.test_robot

TypeError: Module bika.lims.tests.test_robot does not define any tests


Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.572 seconds.
  Set up plone.app.testing.layers.PloneFixture in 15.941 seconds.
  Set up bika.lims.testing.BikaTestLayer in 50.197 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 17 tests with 0 failures and 0 errors in 58.365 seconds.
Running bika.lims.testing.SimpleTestingLayer:Functional tests:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.015 seconds.
  Set up bika.lims.testing.SimpleTestLayer in 7.592 seconds.
  Set up bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 1 tests with 0 failures and 0 errors in 3.132 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.SimpleTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.SimpleTestLayer in 0.007 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.053 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.

Test-modules with import problems:
  bika.lims.tests.test_doctests
  bika.lims.tests.test_robot
Total: 18 tests, 0 failures, 0 errors in 2 minutes 16.612 seconds.
```