### PR TITLE
LIMS-1879 References for product, category and supplier in Product item.

### DIFF
--- a/bika/lims/content/product.py
+++ b/bika/lims/content/product.py
@@ -191,4 +191,7 @@ class Product(BaseContent):
             vatamount = Decimal('0.00')
         return vatamount.quantize(Decimal('0.00'))
 
+    def getSupplierTitle(self):
+        return self.aq_parent.Title()
+
 registerType(Product, config.PROJECTNAME)

--- a/bika/lims/content/productitem.py
+++ b/bika/lims/content/productitem.py
@@ -64,13 +64,13 @@ schema['description'].schemata = 'default'
 schema['description'].widget.visible = True
 
 class ProductItem(BaseContent):
-	implements(IProductItem)
-	schema = schema
-	
-	_at_rename_after_creation = True
+    implements(IProductItem)
+    schema = schema
 
-	def _renameAfterCreation(self, check_auto_id=False):
-		from bika.lims.idserver import renameAfterCreation
-		renameAfterCreation(self)
+    _at_rename_after_creation = True
+
+    def _renameAfterCreation(self, check_auto_id=False):
+        from bika.lims.idserver import renameAfterCreation
+        renameAfterCreation(self)
 
 registerType(ProductItem, config.PROJECTNAME)

--- a/bika/lims/content/productitem.py
+++ b/bika/lims/content/productitem.py
@@ -3,13 +3,44 @@ from Products.Archetypes import atapi
 from bika.lims import bikaMessageFactory as _
 from Products.ATContentTypes.content import base
 from Products.ATContentTypes.content import schemata
+from bika.lims.browser.widgets import DateTimeWidget as bika_DateTimeWidget
+from bika.lims.browser.widgets import ReferenceWidget as bika_ReferenceWidget
 from bika.lims.interfaces import IProductItem
 from bika.lims import config
 from bika.lims.content.bikaschema import BikaSchema
 from DateTime.DateTime import DateTime
 from Products.Archetypes.public import *
+from Products.Archetypes.references import HoldingReference
+from Products.CMFCore.utils import getToolByName
+import sys
 
 schema = BikaSchema.copy() + Schema((
+    ReferenceField('Product',
+        required=1,
+        vocabulary_display_path_bound = sys.maxint,
+        allowed_types=('Product',),
+        relationship='ProductItemProduct',
+        referenceClass=HoldingReference,
+        widget=bika_ReferenceWidget(
+            label = _("Product"),
+            catalog_name='bika_setup_catalog',
+            showOn=True,
+        ),
+    ),
+    ComputedField('SupplierTitle',
+        expression = 'context.getProduct().getSupplierTitle()',
+        widget = ComputedWidget(
+            label=_("Supplier"),
+            visible = {'edit':'hidden', }
+        ),
+    ),
+    ComputedField('ProductCategoryTitle',
+        expression = 'context.getProduct().getCategoryTitle()',
+        widget = ComputedWidget(
+            label=_("Product Category"),
+            visible = {'edit':'hidden', }
+        ),
+    ),
     StringField('orderId',
         widget = StringWidget(
             label=_("Order Id"),
@@ -32,29 +63,25 @@ schema = BikaSchema.copy() + Schema((
     ),
     DateTimeField('dateReceived',
         searchable = 1,
-        required = 0,
-        widget = CalendarWidget(
+        widget = bika_DateTimeWidget(
             label = 'Date Received'
         ),
     ),
     DateTimeField('dateOpened',
         searchable = 1,
-        required = 0,
-        widget = CalendarWidget(
+        widget = bika_DateTimeWidget(
             label = 'Date Opened'
         ),
     ),
     DateTimeField('expiryDate',
         searchable = 1,
-        required = 0,
-        widget = CalendarWidget(
+        widget = bika_DateTimeWidget(
             label = 'Expiry Date'
         ),
     ),
     DateTimeField('disposalDate',
         searchable = 1,
-        required = 0,
-        widget = CalendarWidget(
+        widget = bika_DateTimeWidget(
             label = 'Disposal Date'
         ),
     ),
@@ -72,5 +99,8 @@ class ProductItem(BaseContent):
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
+
+    def getProductTitle(self):
+        return self.getProduct().Title()
 
 registerType(ProductItem, config.PROJECTNAME)

--- a/bika/lims/controlpanel/bika_productitems.py
+++ b/bika/lims/controlpanel/bika_productitems.py
@@ -40,29 +40,27 @@ class ProductItemsView(BikaListingView):
                       'index': 'sortable_title',
                       'toggle': True},
             'orderId': {'title': _('Order Id'),
-                       'index': 'getOrderId',
                        'toggle': True},
             'labId': {'title': _('Lab Id'),
-                       'index': 'getLabId',
-                       'toggle': True},
+                       'toggle': False},
             'batchId': {'title': _('Batch Id'),
-                       'index': 'getBatchId',
+                       'toggle': True},
+            'product': {'title': _('Product'),
+                       'toggle': True},
+            'supplier': {'title': _('Supplier'),
+                       'toggle': True},
+            'productCategory': {'title': _('Category'),
                        'toggle': True},
             'location': {'title': _('Location'),
-                       'index': 'getLocation',
-                       'toggle': True},
+                       'toggle': False},
             'dateReceived': {'title': _('Date Received'),
-                       'index': 'getDateReceived',
                        'toggle': True},
             'dateOpened': {'title': _('Date Opened'),
-                       'index': 'getDateOpened',
                        'toggle': True},
             'expiryDate': {'title': _('Expiry Date'),
-                       'index': 'getExpiryDate',
-                       'toggle': True},
+                       'toggle': False},
             'disposalDate': {'title': _('Disposal Date'),
-                       'index': 'getDisposalDate',
-                       'toggle': True},
+                       'toggle': False},
         }
         self.review_states = [
             {'id':'default',
@@ -73,6 +71,9 @@ class ProductItemsView(BikaListingView):
                          'orderId',
                          'labId',
                          'batchId',
+                         'product',
+                         'supplier',
+                         'productCategory',
                          'location',
                          'dateReceived',
                          'dateOpened',
@@ -86,6 +87,9 @@ class ProductItemsView(BikaListingView):
                          'orderId',
                          'labId',
                          'batchId',
+                         'product',
+                         'supplier',
+                         'productCategory',
                          'location',
                          'dateReceived',
                          'dateOpened',
@@ -98,6 +102,9 @@ class ProductItemsView(BikaListingView):
                          'orderId',
                          'labId',
                          'batchId',
+                         'product',
+                         'Supplier',
+                         'ProductCategory',
                          'location',
                          'dateReceived',
                          'dateOpened',
@@ -113,11 +120,14 @@ class ProductItemsView(BikaListingView):
             items[x]['orderId'] = obj.getOrderId()
             items[x]['labId'] = obj.getLabId()
             items[x]['batchId'] = obj.getBatchId()
+            items[x]['product'] = obj.getProductTitle()
+            items[x]['supplier'] = obj.getSupplierTitle()
+            items[x]['productCategory'] = obj.getProductCategoryTitle()
             items[x]['location'] = obj.getLocation()
-            items[x]['dateReceived'] = obj.getDateReceived()
-            items[x]['dateOpened'] = obj.getDateOpened()
-            items[x]['expiryDate'] = obj.getExpiryDate()
-            items[x]['disposalDate'] = obj.getDisposalDate()
+            items[x]['dateReceived'] = self.ulocalized_time(obj.getDateReceived())
+            items[x]['dateOpened'] = self.ulocalized_time(obj.getDateOpened())
+            items[x]['expiryDate'] = self.ulocalized_time(obj.getExpiryDate())
+            items[x]['disposalDate'] = self.ulocalized_time(obj.getDisposalDate())
             items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
                  (items[x]['url'], items[x]['Title'])
 

--- a/bika/lims/profiles/default/types/ProductItem.xml
+++ b/bika/lims/profiles/default/types/ProductItem.xml
@@ -4,7 +4,7 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="plone"
         purge="True">
- <property name="title" i18n:translate=""></property>
+ <property name="title" i18n:translate="">Product Item</property>
  <property name="description"></property>
  <property name="content_icon">++resource++bika.lims.images/product.png</property>
  <property name="content_meta_type">ProductItem</property>

--- a/bika/lims/tests/test_Product.robot
+++ b/bika/lims/tests/test_Product.robot
@@ -28,24 +28,38 @@ Test Product as LabManager
 
     Given a blank product form in supplier-1
      When I enter the title Water-sampling kit
-      and I select the product category Sampling Kit
+      and I select the category Sampling Kit
       and I enter other fields
       and I submit the form
      Then products list of supplier-1 should contain Water-sampling kit under Sampling Kit
 
     Given a blank product form in supplier-1
      When I enter the title Ziplock bag
-      and I select the product category Kit Component
+      and I select the category Kit Component
       and I submit the form
      Then products list of supplier-1 should contain Ziplock bag under Kit Component
       and page should not contain  Water-sampling kit
 
     Given a blank product form in supplier-2
      When I enter the title Test tube
-      and I select the product category Kit Component
+      and I select the category Kit Component
       and I submit the form
      Then products list of supplier-2 should contain Test tube under Kit Component
       and products list of supplier-1 should not contain Test tube under Kit Component
+
+
+Test ProductItem as LabManager
+    Log in  test_labmanager  test_labmanager
+
+    Add Sampling Kit as product category
+    Add Water-sampling kit as product under Sampling Kit in supplier-1
+
+    Given a blank product item form
+     When I enter the title 12572
+      and I select the product Water-sampling kit
+      and I enter other fields of the item
+      and I submit the form
+     Then product items list should contain 12572, Water-sampling kit, Instruments Inc and Sampling Kit
 
 
 *** Keywords ***
@@ -53,8 +67,13 @@ Test Product as LabManager
 # --- Given ------------------------------------------------------------------
 
 a blank product form in ${supplier}
-    [Documentation]  Load a fresh Order form
+    [Documentation]  Load a fresh Product form
     go to  ${PLONEURL}/bika_setup/bika_suppliers/${supplier}/portal_factory/Product/xxx/edit
+    wait until page contains  xxx
+
+a blank product item form
+    [Documentation]  Load a fresh Product Item form
+    go to  ${PLONEURL}/bika_setup/bika_productitems/portal_factory/ProductItem/xxx/edit
     wait until page contains  xxx
 
 # --- When ------------------------------------------------------------------
@@ -63,7 +82,7 @@ I enter the title ${title}
     [Documentation]  Input the title for the product
     input text  css=#title  ${title}
 
-I select the product category ${category}
+I select the category ${category}
     [Documentation]  Input the product category for the product
     select from list  xpath=//select[contains(@id, 'Category:list')]  ${category}
     
@@ -79,9 +98,16 @@ I enter other fields
     input text  css=#Price  149.99
 
 I submit the form
-    [Documentation]  Save the product and wait for the submission to complete
+    [Documentation]  Save the form and wait for the submission to complete
     click button  Save
     wait until page contains  saved
+
+I select the product ${product}
+    select from dropdown  css=#Product  ${Product}
+
+I enter other fields of the item
+    input text  css=#dateReceived  2015-06-19
+    input text  css=#location  Winterfell
 
 # --- Then ------------------------------------------------------------------
 
@@ -94,6 +120,13 @@ products list of ${supplier} should not contain ${title} under ${category}
     go to  ${PLONEURL}/bika_setup/bika_suppliers/${supplier}/products
     click element  xpath=//th[contains(@cat, '${category}')]
     page should not contain  ${title}
+
+product items list should contain ${title}, ${product}, ${supplier} and ${category}
+    go to  ${PLONEURL}/bika_setup/bika_productitems
+    page should contain  ${title}
+    page should contain  ${product}
+    page should contain  ${supplier}
+    page should contain  ${category}
 
 # --- other ------------------------------------------------------------------
 
@@ -108,5 +141,13 @@ Add ${categoryName} as product category
     go to  ${PLONEURL}/bika_setup/bika_productcategories/portal_factory/ProductCategory/xxx/edit
     wait until page contains  xxx
     input text  css=#title  ${categoryName}
+    click button  Save
+    wait until page contains  saved
+
+Add ${title} as product under ${category} in ${supplier}
+    go to  ${PLONEURL}/bika_setup/bika_suppliers/${supplier}/portal_factory/Product/xxx/edit
+    wait until page contains  xxx
+    input text  css=#title  ${title}
+    select from list  xpath=//select[contains(@id, 'Category:list')]  ${category}
     click button  Save
     wait until page contains  saved

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.9 (unreleased)
 ------------------
+LIMS-1846: Base entities for Inventory Management Module
 LIMS-1869: Not possible to create an Analysis Request
 LIMS-1867: Auto-header, auto-footer and auto-pagination in results reports
 LIMS-1743: Reports: ISO (A4) or ANSI (letter) pdf report size


### PR DESCRIPTION
In addition, calendar widget in Product item is changed to Bika's DateTimeWidget to maintain consistency with other content.

Added robot test for Product Item in test_Product.robot itself:
```
bin/test -t test_Product.robot
Running bika.lims.testing.BikaTestingLayer:Robot tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.173 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.921 seconds.
  Set up bika.lims.testing.BikaTestLayer in 53.756 seconds.
  Set up plone.app.robotframework.remote.RemoteLibraryBundle:RobotRemote in 0.010 seconds.
  Set up plone.testing.z2.ZServer in 0.502 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Running:
    1/2 (50.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)' 
    2/2 (100.0%)[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)' 
                
  Ran 2 tests with 0 failures and 0 errors in 1 minutes 14.121 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Tear down plone.app.robotframework.remote.RemoteLibraryBundle:RobotRemote in 0.004 seconds.
  Tear down plone.testing.z2.ZServer in 5.026 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.017 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.064 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.007 seconds.
```