### PR TITLE
Overrode breadcrumbs in Product view

### DIFF
--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -3,8 +3,11 @@ from bika.lims.controlpanel.bika_instruments import InstrumentsView
 from bika.lims.controlpanel.bika_products import ProductsView
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
-from Products.CMFCore.utils import getToolByName
 from bika.lims.utils import to_utf8
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getMultiAdapter
 
 class SupplierInstrumentsView(InstrumentsView):
 
@@ -62,6 +65,20 @@ class SupplierProductsView(ProductsView):
                      (items[x]['url'], items[x]['Title'], after_icons)
                 outitems.append(items[x])
         return outitems
+
+
+class ProductPathBarViewlet(ViewletBase):
+    """Viewlet for overriding breadcrumbs in Product View"""
+
+    index = ViewPageTemplateFile('templates/path_bar.pt')
+
+    def update(self):
+        super(ProductPathBarViewlet, self).update()
+        self.is_rtl = self.portal_state.is_rtl()
+        breadcrumbs = getMultiAdapter((self.context, self.request),
+                                      name='breadcrumbs_view').breadcrumbs()
+        breadcrumbs[2]['absolute_url'] += '/products'
+        self.breadcrumbs = breadcrumbs
 
 
 class ReferenceSamplesView(BikaListingView):

--- a/bika/lims/browser/supplier.zcml
+++ b/bika/lims/browser/supplier.zcml
@@ -36,4 +36,15 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <!-- Translated breadcrumbs -->
+    <browser:viewlet
+      for="bika.lims.interfaces.IProduct"
+      name="plone.path_bar"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/path_bar.pt"
+      class="bika.lims.browser.supplier.ProductPathBarViewlet"
+      permission="zope2.View"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
 </configure>


### PR DESCRIPTION
Clicking on a supplier in the breadcrumbs of Product view redirects to Products list instead of reference samples.