### PR TITLE
LIMS-1887 uniquefield validator doesn't work properly

### DIFF
--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -33,7 +33,13 @@ class UniqueFieldValidator:
         for item in aq_parent(instance).objectValues():
             if hasattr(item, 'UID') and item.UID() != instance.UID() and \
                fieldname in item.Schema() and \
-               item.Schema()[fieldname].get(item) == value:
+               str(item.Schema()[fieldname].get(item)) == str(value):   # We have to compare them as strings because
+                                                                        # even if a number (as an  id) is saved inside
+                                                                        # a string widget and string field, it will be
+                                                                        # returned as an int. I don't know if it is
+                                                                        # caused because is called with
+                                                                        # <item.Schema()[fieldname].get(item)>,
+                                                                        # but it happens...
                 msg = _("Validation failed: '${value}' is not unique",
                         mapping={'value': safe_unicode(value)})
                 return to_utf8(translate(msg))

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.9 (unreleased)
 ------------------
+LIMS-1887: uniquefield validator doesn't work properly
 LIMS-1869: Not possible to create an Analysis Request
 LIMS-1867: Auto-header, auto-footer and auto-pagination in results reports
 LIMS-1743: Reports: ISO (A4) or ANSI (letter) pdf report size


### PR DESCRIPTION
https://jira.bikalabs.com/browse/LIMS-1887

A pdb trace example:

-> for item in aq_parent(instance).objectValues():
(Pdb) item
<Method at /Plone/methods/method-1>
(Pdb) hasattr(item, 'UID') and item.UID() != instance.UID() and fieldname in item.Schema() and item.Schema()[fieldname].get(item) == value
False
(Pdb) value
'1212'
(Pdb) item.Schema()[fieldname].get(it)
1212
(Pdb) type(value) == type(it.Schema()[fieldname].get(it))
False
(Pdb) type(it.Schema()[fieldname].get(it))
<type 'int'>