### PR TITLE
Fix LIMS-1930: AssertionError: Having an orphan size, higher than batch size is undefined

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -43,7 +43,7 @@ class AnalysesView(BikaListingView):
         self.show_select_row = False
         self.show_select_column = False
         self.show_column_toggles = False
-        self.pagesize = 0
+        self.pagesize = 999999
         self.form_id = 'analyses_form'
 
         self.portal = getToolByName(context, 'portal_url').getPortalObject()

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -68,7 +68,7 @@ class AnalysisServicesView(ASV):
 
         self.filter_indexes = ['id', 'Title', 'SearchableText', 'getKeyword']
 
-        self.pagesize = 0
+        self.pagesize = 999999
         self.table_only = True
 
         default = [x for x in self.review_states if x['id'] == 'default'][0]

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -39,7 +39,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.show_select_column = True
         self.table_only = True
         self.show_select_all_checkbox = False
-        self.pagesize = 0
+        self.pagesize = 999999
 
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()

--- a/bika/lims/browser/batch/batchbook.py
+++ b/bika/lims/browser/batch/batchbook.py
@@ -26,7 +26,7 @@ class BatchBookView(BikaListingView):
         self.show_column_toggles = True
         self.show_select_row = False
         self.show_select_column = True
-        self.pagesize = 0
+        self.pagesize = 999999
         self.form_id = "list"
         self.page_start_index = 0
         self.show_categories = True

--- a/bika/lims/browser/log.py
+++ b/bika/lims/browser/log.py
@@ -34,7 +34,7 @@ class LogView(BikaListingView):
         self.show_select_row = False
         self.show_select_column = False
         self.show_workflow_action_buttons = False
-        self.pagesize = 0
+        self.pagesize = 999999
 
         self.icon = self.portal_url + "/++resource++bika.lims.images/%s_big.png" % \
             context.portal_type.lower()

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -223,7 +223,7 @@ class ReferenceResultsView(BikaListingView):
         self.show_select_row = False
         self.show_workflow_action_buttons = False
         self.show_select_column = False
-        self.pagesize = 0
+        self.pagesize = 999999
 
         self.columns = {
             'Service': {'title': _('Service')},

--- a/bika/lims/browser/sample.py
+++ b/bika/lims/browser/sample.py
@@ -44,7 +44,7 @@ class SamplePartitionsView(BikaListingView):
         self.show_column_toggles = False
         self.show_select_row = False
         self.show_select_column = True
-        self.pagesize = 0
+        self.pagesize = 999999
         self.form_id = "partitions"
 
         self.columns = {

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -36,7 +36,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:
-            self.pagesize = 0  # hide batching controls
+            self.pagesize = 999999  # hide batching controls
             self.show_categories = True
             self.expand_all_categories = False
             self.ajax_categories = True

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -27,7 +27,7 @@ class AnalysisSpecificationView(BikaListingView):
         self.show_select_row = False
         self.show_select_all_checkbox = False
         self.show_select_column = False
-        self.pagesize = 0
+        self.pagesize = 999999
         self.allow_edit = allow_edit
         self.show_categories = True
         # self.expand_all_categories = False

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -35,7 +35,7 @@ class ARTemplateAnalysesView(BikaListingView):
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:
-            self.pagesize = 0  # hide batching controls
+            self.pagesize = 999999  # hide batching controls
             self.show_categories = True
             self.expand_all_categories = False
             self.ajax_categories = True

--- a/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/bika/lims/browser/widgets/referenceresultswidget.py
@@ -27,7 +27,7 @@ class ReferenceResultsView(BikaListingView):
         self.show_select_row = False
         self.show_select_all_checkbox = False
         self.show_select_column = False
-        self.pagesize = 0
+        self.pagesize = 999999
         self.allow_edit = allow_edit
         self.show_categories = True
         # self.expand_all_categories = False

--- a/bika/lims/browser/widgets/serviceswidget.py
+++ b/bika/lims/browser/widgets/serviceswidget.py
@@ -30,7 +30,7 @@ class ServicesView(BikaListingView):
         self.show_select_row = False
         self.show_select_all_checkbox = False
         self.show_select_column = True
-        self.pagesize = 0
+        self.pagesize = 999999
         self.form_id = 'serviceswidget'
 
         self.columns = {

--- a/bika/lims/browser/widgets/srtemplateartemplateswidget.py
+++ b/bika/lims/browser/widgets/srtemplateartemplateswidget.py
@@ -29,7 +29,7 @@ class SRTemplateARTemplatesView(BikaListingView):
         self.show_select_column = True
         self.show_categories = True
         self.expand_all_categories = True
-        self.pagesize = 0
+        self.pagesize = 999999
         self.allow_edit = allow_edit
         self.form_id = "artemplates"
         self.columns = {

--- a/bika/lims/browser/worksheet.py
+++ b/bika/lims/browser/worksheet.py
@@ -1299,7 +1299,7 @@ class WorksheetServicesView(BikaListingView):
         self.show_select_row = False
         self.show_select_all_checkbox = False
         self.show_select_column = True
-        self.pagesize = 0
+        self.pagesize = 999999
         self.show_workflow_action_buttons = False
         self.show_categories=context.bika_setup.getCategoriseAnalysisServices()
         self.expand_all_categories=True

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -145,7 +145,7 @@ class AnalysisServicesView(BikaListingView):
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:
-            self.pagesize = 0  # hide batching controls
+            self.pagesize = 999999  # hide batching controls
             self.show_categories = True
             self.expand_all_categories = False
             self.ajax_categories = True


### PR DESCRIPTION
Using pagesize=0 was a shortcut to hide the batching/pagination controls but in Plone > 4.3.4 causes this error in lists with 0 items.

Now using '999999' for the pagesize of these listings.