### PR TITLE
LIMS-1961 Product Storage

### DIFF
--- a/bika/lims/browser/order/configure.zcml
+++ b/bika/lims/browser/order/configure.zcml
@@ -101,4 +101,12 @@
      layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <browser:page
+      for="bika.lims.interfaces.IOrder"
+      name="store"
+      class="bika.lims.browser.order.order.OrderStore"
+      permission="cmf.ModifyPortalContent"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
 </configure>

--- a/bika/lims/browser/order/templates/order_view.pt
+++ b/bika/lims/browser/order/templates/order_view.pt
@@ -1,21 +1,28 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:tal="http://xml.zope.org/namespaces/tal"
-	xmlns:metal="http://xml.zope.org/namespaces/metal"
-	xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	metal:use-macro="here/main_template/macros/master"
-	i18n:domain="bika">
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    metal:use-macro="here/main_template/macros/master"
+    i18n:domain="bika">
 
-	<head></head>
+    <head>
+        <metal:block fill-slot="javascript_head_slot"
+            tal:define="portal context/@@plone_portal_state/portal;">
+        <script type="text/javascript"
+                tal:attributes="src python:portal.absolute_url() + '/bika_widgets/referencewidget.js'"></script>
+    </metal:block>
+	</head>
 
-	<body>
+    <body>
 
-		<metal:title fill-slot="content-title">
-			<h1>
-				<span class="documentFirstHeading" tal:content="view/title" />
-			</h1>
-		</metal:title>
+        <metal:title fill-slot="content-title">
+            <h1>
+                <span class="documentFirstHeading" tal:content="view/title" />
+            </h1>
+        </metal:title>
 
-		<metal:core fill-slot="content-core">
+        <metal:core fill-slot="content-core"
+            tal:define="received python:context.portal_workflow.getInfoFor(context, 'review_state') == 'received'">
             <table class="invoice-header">
                 <tbody>
                 <tr>
@@ -33,6 +40,8 @@
                     <th i18n:translate="">Price</th>
                     <th i18n:translate="">VAT</th>
                     <th i18n:translate="">Quantity</th>
+                    <th i18n:translate="" title="Number of items to store" tal:condition="received">Number</th>
+                    <th i18n:translate="" tal:condition="received">Storage level</th>
                     <th class="currency" i18n:translate="">Total</th>
                 </tr>
                 </thead>
@@ -48,6 +57,39 @@
                             </td>
                             <td class="center" tal:content="item/vat"></td>
                             <td class="number" tal:content="item/quantity"></td>
+                            <td tal:condition="received"><input type="number" min=0 style="width: 70px"/></td>
+                            <td tal:condition="received">
+                                <form>
+                                    <div style="width:100%" class="field ArchetypesReferenceWidget">
+                                        <input
+                                            type="text"
+                                            name="Storage"
+                                            id="Storage"
+                                            class="blurrable firstToFocus referencewidget"
+                                            value=""
+                                            size=14
+                                            base_query='{"portal_type": "StorageLevel"}'
+                                            search_query='{}'
+                                            catalog_name="bika_setup_catalog"
+                                            ui_item="Title"
+                                            autocomplete="false"
+                                            combogrid_options='{"colModel": [{"columnName": "Title", "align": "left", "label": "Title", "width": "100"}],
+                                                                "search_fields": ["Title"],
+                                                                "catalog_name": "bika_setup_catalog",
+                                                                "url": "referencewidget_search",
+                                                                "discard_empty": [],
+                                                                "popup_width": "550px",
+                                                                "showOn": true,
+                                                                "searchIcon": true,
+                                                                "minLength": "0",
+                                                                "resetButton": false,
+                                                                "sord": "asc",
+                                                                "sidx": "Title",
+                                                                "force_all": true,
+                                                                "portal_types": {}}'/>
+                                    </div>
+                                </form>
+                            </td>
                             <td class="currency">
                                 <span tal:content="item/totalprice"></span>
                             </td>
@@ -55,21 +97,24 @@
                     </tal:item>
                 </tal:items>
                 <tr class="totals">
-                    <td colspan="6" i18n:translate="">Subtotal</td>
+                    <td colspan="6" i18n:translate="" tal:condition="python:not received">Subtotal</td>
+                    <td colspan="8" i18n:translate="" tal:condition="received">Subtotal</td>
                     <td class="currency">
                         <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
                         <span class="subtotal" tal:content="view/subtotal"></span>
                     </td>
                 </tr>
                 <tr class="totals">
-                    <td colspan="6" i18n:translate="">VAT</td>
+                    <td colspan="6" i18n:translate="" tal:condition="python:not received">VAT</td>
+                    <td colspan="8" i18n:translate="" tal:condition="received">VAT</td>
                     <td class="currency">
                         <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
                         <span class="vat" tal:content="view/vat"></span>
                     </td>
                 </tr>
                 <tr class="totals">
-                    <td colspan="6" i18n:translate="">Total</td>
+                    <td colspan="6" i18n:translate="" tal:condition="python:not received">Total</td>
+                    <td colspan="8" i18n:translate="" tal:condition="received">Total</td>
                     <td class="currency">
                         <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
                         <span class="total" tal:content="view/total"></span>

--- a/bika/lims/browser/order/templates/order_view.pt
+++ b/bika/lims/browser/order/templates/order_view.pt
@@ -68,7 +68,7 @@
                                             class="blurrable firstToFocus referencewidget"
                                             value=""
                                             size=14
-                                            base_query='{"portal_type": "StorageLevel"}'
+                                            base_query='{"portal_type": "StorageLevel", "object_provides": "bika.lims.interfaces.IStorageLevelIsAssignable"}'
                                             search_query='{}'
                                             catalog_name="bika_setup_catalog"
                                             ui_item="Title"

--- a/bika/lims/browser/order/templates/order_view.pt
+++ b/bika/lims/browser/order/templates/order_view.pt
@@ -31,50 +31,75 @@
                 </tr>
                 </tbody>
             </table>
-            <table class="invoice-items items">
-                <thead>
-                <tr>
-                    <th i18n:translate="">Product</th>
-                    <th i18n:translate="">Description</th>
-                    <th i18n:translate="">Unit</th>
-                    <th i18n:translate="">Price</th>
-                    <th i18n:translate="">VAT</th>
-                    <th i18n:translate="">Quantity</th>
-                    <th i18n:translate="" title="Number of items to store" tal:condition="received">Number</th>
-                    <th i18n:translate="" tal:condition="received">Storage level</th>
-                    <th class="currency" i18n:translate="">Total</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tal:items repeat="item view/items">
-                    <tal:item>
-                        <tr>
-                            <td tal:content="item/title"></td>
-                            <td class="text center" tal:content="item/description"></td>
-                            <td class="center" tal:content="item/unit"></td>
-                            <td class="currency center">
-                                <span tal:content="item/price"></span>
-                            </td>
-                            <td class="center" tal:content="item/vat"></td>
-                            <td class="number" tal:content="item/quantity"></td>
-                            <td tal:condition="received"><input type="number" min=0 style="width: 70px"/></td>
-                            <td tal:condition="received">
-                                <form>
-                                    <div style="width:100%" class="field ArchetypesReferenceWidget">
+            <form name="order-storage" method="post" action="store">
+                <table class="invoice-items items">
+                    <thead>
+                    <tr>
+                        <th i18n:translate="">Product</th>
+                        <th i18n:translate="" tal:condition="python:not received">Description</th>
+                        <th i18n:translate="" tal:condition="python:not received">Unit</th>
+                        <th i18n:translate="">Price</th>
+                        <th i18n:translate="">VAT</th>
+                        <th i18n:translate="" tal:condition="python:not received">Ordered</th>
+                        <th i18n:translate="" tal:condition="received">Ordered (stored)</th>
+                        <th i18n:translate="" title="Number of items to store" tal:condition="received">Number</th>
+                        <th i18n:translate="" tal:condition="received">Storage level</th>
+                        <th class="currency" i18n:translate="">Total</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tal:items repeat="item view/items">
+                        <tal:item>
+                            <tr>
+                                <td tal:content="item/title" tal:attributes="id item/prodid"></td>
+                                <td class="text center" tal:content="item/description" tal:condition="python:not received"></td>
+                                <td class="center" tal:content="item/unit" tal:condition="python:not received"></td>
+                                <td class="currency center">
+                                    <span tal:content="item/price"></span>
+                                </td>
+                                <td class="center" tal:content="item/vat"></td>
+                                <td class="number" tal:content="item/quantity" tal:condition="python:not received"></td>
+                                <td class="number"
+                                    tal:content="python:str(item['quantity']) + ' (' + str(item['stored']) + ')'"
+                                    tal:condition="received">
+                                </td>
+                                <td tal:condition="received">
+                                    <div class="center" tal:condition="item/all_stored"> - </div>
+                                    <div class="center" tal:condition="python: not item['all_stored']">
+                                        <input
+                                            min=0
+                                            type="number"
+                                            style="width: 50px"
+                                            tal:attributes="max python:item['quantity']-item['stored'];
+                                                            name python:'number-' + str(item['prodid'])"/>
+                                    </div>
+                                </td>
+                                <td tal:condition="received">
+                                    <div class="center" tal:condition="item/all_stored"> - </div>
+                                    <div style="width:100%" class="field ArchetypesReferenceWidget center" tal:condition="python:not item['all_stored']">
                                         <input
                                             type="text"
-                                            name="Storage"
-                                            id="Storage"
                                             class="blurrable firstToFocus referencewidget"
                                             value=""
-                                            size=14
+                                            size=25
+                                            tal:attributes="name python:'storage-' + str(item['prodid'])"
                                             base_query='{"portal_type": "StorageLevel", "object_provides": "bika.lims.interfaces.IStorageLevelIsAssignable"}'
                                             search_query='{}'
                                             catalog_name="bika_setup_catalog"
-                                            ui_item="Title"
+                                            ui_item="Hierarchy"
                                             autocomplete="false"
-                                            combogrid_options='{"colModel": [{"columnName": "Title", "align": "left", "label": "Title", "width": "100"}],
-                                                                "search_fields": ["Title"],
+                                            combogrid_options='{"colModel":[{
+                                                                    "columnName": "Hierarchy",
+                                                                    "align": "left",
+                                                                    "label": "Storage Level",
+                                                                    "width": "90"
+                                                                }, {
+                                                                    "columnName": "NumberOfAvailableChildren",
+                                                                    "align": "center",
+                                                                    "label": "no.",
+                                                                    "width": "10"
+                                                                }],
+                                                                "search_fields": ["Hierarchy"],
                                                                 "catalog_name": "bika_setup_catalog",
                                                                 "url": "referencewidget_search",
                                                                 "discard_empty": [],
@@ -84,46 +109,44 @@
                                                                 "minLength": "0",
                                                                 "resetButton": false,
                                                                 "sord": "asc",
-                                                                "sidx": "Title",
+                                                                "sidx": "Hierarchy",
                                                                 "force_all": true,
                                                                 "portal_types": {}}'/>
                                     </div>
-                                </form>
-                            </td>
-                            <td class="currency">
-                                <span tal:content="item/totalprice"></span>
-                            </td>
-                        </tr>
-                    </tal:item>
-                </tal:items>
-                <tr class="totals">
-                    <td colspan="6" i18n:translate="" tal:condition="python:not received">Subtotal</td>
-                    <td colspan="8" i18n:translate="" tal:condition="received">Subtotal</td>
-                    <td class="currency">
-                        <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
-                        <span class="subtotal" tal:content="view/subtotal"></span>
-                    </td>
-                </tr>
-                <tr class="totals">
-                    <td colspan="6" i18n:translate="" tal:condition="python:not received">VAT</td>
-                    <td colspan="8" i18n:translate="" tal:condition="received">VAT</td>
-                    <td class="currency">
-                        <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
-                        <span class="vat" tal:content="view/vat"></span>
-                    </td>
-                </tr>
-                <tr class="totals">
-                    <td colspan="6" i18n:translate="" tal:condition="python:not received">Total</td>
-                    <td colspan="8" i18n:translate="" tal:condition="received">Total</td>
-                    <td class="currency">
-                        <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
-                        <span class="total" tal:content="view/total"></span>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-		</metal:core>
+                                </td>
+                                <td class="currency">
+                                    <span tal:content="item/totalprice"></span>
+                                </td>
+                            </tr>
+                        </tal:item>
+                    </tal:items>
+                    <tr class="totals">
+                        <td colspan="6" i18n:translate="">Subtotal</td>
+                        <td class="currency">
+                            <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
+                            <span class="subtotal" tal:content="view/subtotal"></span>
+                        </td>
+                    </tr>
+                    <tr class="totals">
+                        <td colspan="6" i18n:translate="">VAT</td>
+                        <td class="currency">
+                            <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
+                            <span class="vat" tal:content="view/vat"></span>
+                        </td>
+                    </tr>
+                    <tr class="totals">
+                        <td colspan="6" i18n:translate="">Total</td>
+                        <td class="currency">
+                            <span tal:content="python:view.getPreferredCurrencyAbreviation()">$</span>
+                            <span class="total" tal:content="view/total"></span>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                <input type="submit" name="submit" value="Store" tal:condition="received"/>
+            </form>
+        </metal:core>
 
-	</body>
+    </body>
 
 </html>

--- a/bika/lims/content/productitem.py
+++ b/bika/lims/content/productitem.py
@@ -94,6 +94,16 @@ schema = BikaSchema.copy() + Schema((
             label = 'Disposal Date'
         ),
     ),
+    BooleanField(
+        'IsStored',
+        default=False,
+        widget=BooleanWidget(visible=False),
+    ),
+    StringField('StorageLevelID',
+        widget = StringWidget(
+            label=_("Location"),
+        )
+    ),
 ))
 
 schema['title'].required = False

--- a/bika/lims/content/storagelevel.py
+++ b/bika/lims/content/storagelevel.py
@@ -1,31 +1,32 @@
 from AccessControl import ClassSecurityInfo
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims.config import PROJECTNAME
-from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.content.bikaschema import BikaFolderSchema
+from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IStorageLevel
+from bika.lims.interfaces import IStorageLevelIsAssignable
+from bika.lims.utils import t
 from plone.app.folder.folder import ATFolder
 from Products.Archetypes.public import *
 from Products.CMFCore.permissions import View, ModifyPortalContent
+from zope.interface import alsoProvides, noLongerProvides
 from zope.interface import implements
 
 schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
-    ComputedField('ParentUID',
-        expression = 'context.aq_parent.UID()',
-        widget = ComputedWidget(
-            visible = False,
+    ComputedField(
+        'ParentUID',
+        expression='context.aq_parent.UID()',
+        widget=ComputedWidget(
+            visible=False,
         ),
     ),
-    BooleanField('IsAssignable',
+    BooleanField(
+        'HasChildren',
         default=False,
         widget=BooleanWidget(visible=False),
     ),
-    BooleanField('HasChildren',
-        default=False,
-        widget=BooleanWidget(visible=False),
-    ),
-    IntegerField('NumberOfChildlessChildren',
+    IntegerField(
+        'NumberOfChildlessChildren',
         default=0,
         widget=IntegerWidget(visible=False)
     ),
@@ -34,6 +35,7 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
 schema['description'].schemata = 'default'
 schema['description'].widget.visible = True
 
+
 class StorageLevel(ATFolder):
     implements(IStorageLevel)
     security = ClassSecurityInfo()
@@ -41,28 +43,31 @@ class StorageLevel(ATFolder):
     schema = schema
 
     _at_rename_after_creation = True
+
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
+
         renameAfterCreation(self)
 
     def at_post_create_script(self):
         # Jira LIMS-1961
         if hasattr(self.aq_parent, 'getNumberOfChildlessChildren'):
             number = self.aq_parent.getNumberOfChildlessChildren()
-            self.aq_parent.setNumberOfChildlessChildren(number+1)
-            self.aq_parent.setIsAssignable(True)
+            self.aq_parent.setNumberOfChildlessChildren(number + 1)
+            alsoProvides(self.aq_parent, IStorageLevelIsAssignable)
 
-        if hasattr(self.aq_parent, 'HasChildren') and not self.aq_parent.HasChildren:
+        if hasattr(self.aq_parent, 'HasChildren') and not \
+                self.aq_parent.HasChildren:
             self.aq_parent.setHasChildren(True)
             grand_parent = self.aq_parent.aq_parent
 
             if hasattr(self.aq_parent, 'aq_parent') and \
-               hasattr(grand_parent, 'getNumberOfChildlessChildren'):
+                    hasattr(grand_parent, 'getNumberOfChildlessChildren'):
                 number = grand_parent.getNumberOfChildlessChildren()
-                grand_parent.setNumberOfChildlessChildren(number-1)
+                grand_parent.setNumberOfChildlessChildren(number - 1)
 
                 if number <= 1:
-                    grand_parent.setIsAssignable(False)
+                    noLongerProvides(grand_parent, IStorageLevelIsAssignable)
 
 
 registerType(StorageLevel, PROJECTNAME)

--- a/bika/lims/content/storagelevel.py
+++ b/bika/lims/content/storagelevel.py
@@ -68,6 +68,7 @@ class StorageLevel(ATFolder):
 
                 if number <= 1:
                     noLongerProvides(grand_parent, IStorageLevelIsAssignable)
+        self.reindexObject(idxs=['object_provides'])
 
 
 registerType(StorageLevel, PROJECTNAME)

--- a/bika/lims/controlpanel/bika_productitems.py
+++ b/bika/lims/controlpanel/bika_productitems.py
@@ -61,6 +61,10 @@ class ProductItemsView(BikaListingView):
                        'toggle': False},
             'disposalDate': {'title': _('Disposal Date'),
                        'toggle': False},
+            'storageLevelId': {'title': _('Storage Level ID'),
+                       'toggle': False},
+            'isStored': {'title': _('Is Stored'),
+                       'toggle': False},
         }
         self.review_states = [
             {'id':'default',
@@ -75,6 +79,8 @@ class ProductItemsView(BikaListingView):
                          'supplier',
                          'productCategory',
                          'location',
+                         'storageLevelId',
+                         'isStored',
                          'dateReceived',
                          'dateOpened',
                          'expiryDate',
@@ -91,6 +97,8 @@ class ProductItemsView(BikaListingView):
                          'supplier',
                          'productCategory',
                          'location',
+                         'storageLevelId',
+                         'isStored',
                          'dateReceived',
                          'dateOpened',
                          'expiryDate',
@@ -106,6 +114,8 @@ class ProductItemsView(BikaListingView):
                          'Supplier',
                          'ProductCategory',
                          'location',
+                         'storageLevelId',
+                         'isStored',
                          'dateReceived',
                          'dateOpened',
                          'expiryDate',
@@ -124,6 +134,8 @@ class ProductItemsView(BikaListingView):
             items[x]['supplier'] = obj.getSupplierTitle()
             items[x]['productCategory'] = obj.getProductCategoryTitle()
             items[x]['location'] = obj.getLocation()
+            items[x]['storageLevelId'] = obj.getStorageLevelID()
+            items[x]['isStored'] = 'yes' if obj.getIsStored() else 'no'
             items[x]['dateReceived'] = self.ulocalized_time(obj.getDateReceived())
             items[x]['dateOpened'] = self.ulocalized_time(obj.getDateOpened())
             items[x]['expiryDate'] = self.ulocalized_time(obj.getExpiryDate())

--- a/bika/lims/controlpanel/bika_storagelevels.py
+++ b/bika/lims/controlpanel/bika_storagelevels.py
@@ -70,6 +70,9 @@ class StorageLevelsView(BikaListingView):
         ]
 
     def folderitems(self):
+        catalog = getToolByName(self.context, 'bika_setup_catalog')
+        from bika.lims.interfaces import IStorageLevelIsAssignable
+        print(catalog(object_provides=IStorageLevelIsAssignable))
         items = BikaListingView.folderitems(self)
         for x in range(len(items)):
             if not items[x].has_key('obj'): continue

--- a/bika/lims/controlpanel/bika_storagelevels.py
+++ b/bika/lims/controlpanel/bika_storagelevels.py
@@ -48,6 +48,12 @@ class StorageLevelsView(BikaListingView):
                       'index': 'sortable_title'},
             'Description': {'title': _('Description'),
                                 'toggle': True},
+            'Hierarchy': {'title': _('Hierarchy'),
+                                'toggle': False},
+            'ProductItemID': {'title': _('Product Item ID'),
+                                'toggle': True},
+            'IsOccupied': {'title': _('Is Occupied'),
+                                'toggle': False},
         }
         self.review_states = [
             {'id':'default',
@@ -55,35 +61,44 @@ class StorageLevelsView(BikaListingView):
              'contentFilter': {'inactive_state': 'active'},
              'transitions': [{'id':'deactivate'}, ],
              'columns': ['Title',
-                         'Description']},
+                         'Description',
+                         'Hierarchy',
+                         'ProductItemID',
+                         'IsOccupied']},
             {'id':'inactive',
              'title': _('Dormant'),
              'contentFilter': {'inactive_state': 'inactive'},
              'transitions': [{'id':'activate'}, ],
              'columns': ['Title',
-                         'Description']},
+                         'Description',
+                         'Hierarchy',
+                         'ProductItemID',
+                         'IsOccupied']},
             {'id':'all',
              'title': _('All'),
              'contentFilter':{},
              'columns': ['Title',
-                         'Description']},
+                         'Description',
+                         'Hierarchy',
+                         'ProductItemID',
+                         'IsOccupied']},
         ]
 
     def folderitems(self):
-        catalog = getToolByName(self.context, 'bika_setup_catalog')
-        from bika.lims.interfaces import IStorageLevelIsAssignable
-        print(catalog(object_provides=IStorageLevelIsAssignable))
         items = BikaListingView.folderitems(self)
         for x in range(len(items)):
             if not items[x].has_key('obj'): continue
             obj = items[x]['obj']
             items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
                  (items[x]['url'], items[x]['Title'])
+            items[x]['ProductItemID'] = obj.getProductItemID()
+            items[x]['IsOccupied'] = 'yes' if obj.getIsOccupied() else 'no'
+            items[x]['Hierarchy'] = obj.getHierarchy()
         return items
 
 
 class AddStorageLevelView(BrowserView):
-    """ Handler for the "Add Storage levels" button in Storage levels 
+    """ Handler for the "Add Storage levels" button in Storage levels
         view.
     """
 

--- a/bika/lims/controlpanel/bika_storagelevels.py
+++ b/bika/lims/controlpanel/bika_storagelevels.py
@@ -81,8 +81,7 @@ class StorageLevelsView(BikaListingView):
 
 class AddStorageLevelView(BrowserView):
     """ Handler for the "Add Storage levels" button in Storage levels 
-        view. If a template was selected, the worksheet is pre-populated
-        here.
+        view.
     """
 
     def StorageLevelTitleExists(self, title):

--- a/bika/lims/controlpanel/templates/storagelevels.pt
+++ b/bika/lims/controlpanel/templates/storagelevels.pt
@@ -21,7 +21,8 @@
         <img tal:condition="view/getPriorityIcon | nothing"
              src="" tal:attributes="src view/getPriorityIcon"/>
         <span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="python:view.context.translate(view.title)"/>
-        <tal:add_actions repeat="add_item python:view.context_actions.keys()">
+        <tal:add_actions repeat="add_item python:view.context_actions.keys()"
+                         tal:condition="python: not view.context.getIsOccupied()">
             <a tal:attributes="
                 style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
                 href python:view.context_actions[add_item]['url'];
@@ -43,6 +44,7 @@
         tal:condition="view/description"/>
 
     <div class="storagelevel_add_controls"
+        tal:condition="python: not view.context.getIsOccupied()"
         style="padding-top: 10px;">
         <form name="storagelevel-add-form" action="storagelevel_add" method="POST">
             <input name="storagelevel-title"

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -715,3 +715,9 @@ class IOrder(Interface):
 
 class IOrderFolder(Interface):
     "Interface for Order Folder for Inventory"
+
+class IStorageLevelIsAssignable(Interface):
+    """Just testing with alsoProvides and object_provides index
+    This interface should then be used to mark all storage levels
+    """
+

--- a/bika/lims/monkey/contentmenu.py
+++ b/bika/lims/monkey/contentmenu.py
@@ -24,6 +24,7 @@ def contentmenu_factories_available(self):
         'ReportFolder',
         'SampleType',
         'SamplePoint',
+        'StorageLevel',
         'StorageLocation',
         'WorksheetTemplate',
         'LabProduct',

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -784,6 +784,7 @@ class BikaGenerator:
         addIndex(bsc, 'created', 'DateIndex')
         addIndex(bsc, 'Creator', 'FieldIndex')
         addIndex(bsc, 'getObjPositionInParent', 'GopipIndex')
+        addIndex(bsc, 'object_provides', 'KeywordIndex')
 
         addIndex(bsc, 'title', 'FieldIndex', 'Title')
         addIndex(bsc, 'sortable_title', 'FieldIndex')

--- a/bika/lims/tests/test_InventoryOrder.robot
+++ b/bika/lims/tests/test_InventoryOrder.robot
@@ -39,17 +39,22 @@ Test order as LabManager
     Then when I trigger store transition
     page should contain  Item state changed
 
-Test order reception as LabManager
+Test product reception and storage as LabManager
     Enable autologin as  LabManager
     Disable auto print inventory stickers
+    Add storage levels
     # https://jira.bikalabs.com/browse/LIMS-1936
 
     Given a dispatched order in supplier-3 with 5 items of Nitric acid
      When I trigger receive transition
      Then new product items appear in the list under order-1
       and quantity of the Chemical named Nitric acid supplied by supplier-3 is 5
-      and I can print stickers by clicking an icon in order-1 of supplier-3
 
+     When I store 3 items of Nitric acid in Freezer > Drawer-1
+     Then page should contain  5 (3)
+      and products items are assigned to containers in Drawer-1 of Freezer
+     When I store 2 items of Nitric acid in Warehouse > Row-1 > Shelf-1
+     Then page should contain  5 (5)
 
 *** Keywords ***
 
@@ -90,6 +95,12 @@ I trigger ${transitionId} transition
 I publish the order
     Click button  Publish
 
+I store ${number} items of Nitric acid in ${storage}
+    Go to  ${PLONEURL}/bika_setup/bika_suppliers/supplier-3/order-1
+    input text  number-product-8  ${number}
+    select from dropdown  storage-product-8  ${storage}
+    click button  Store
+
 # --- Then -------------------------------------------------------------------
 
 status message should be ${message}
@@ -126,7 +137,29 @@ I can print stickers by clicking an icon in ${order} of ${supplier}
     click element  //img[@title='Small Sticker']
     location should be  ${PLONEURL}/bika_setup/bika_suppliers/${supplier}/${order}/stickers
 
+products items are assigned to containers in Drawer-1 of Freezer
+    go to  ${PLONEURL}/bika_setup/bika_storageunits
+    click link  Freezer
+    click link  Drawer-1
+    page should contain  P-0001
+    page should contain  P-0003
+
 # --- Other -------------------------------------------------------------------
+
+Add storage levels
+    Add Freezer as storage unit
+    Add 3 storage levels with title Drawer
+    click link  Drawer-1
+    Add 10 storage levels with title Container
+
+    Add Warehouse as storage unit
+    Add 2 storage levels with title Row
+    click link  Row-1
+    Add 2 storage levels with title Shelf
+    click link  Shelf-1
+    Add 10 storage levels with title Container
+    Go to Shelf-2 in Row-1 of Warehouse
+    Add 10 storage levels with title Container
 
 Disable auto print inventory stickers
     go to  ${PLONEURL}/bika_setup/
@@ -134,3 +167,23 @@ Disable auto print inventory stickers
     unselect checkbox  css=#AutoPrintInventoryStickers
     click button  Save
     wait until page contains  saved
+
+
+Add ${title} as storage unit
+    go to  ${PLONEURL}/bika_setup/bika_storageunits/portal_factory/StorageUnit/xxx/edit
+    wait until page contains  xxx
+    input text  css=#title  ${title}
+    click button  Save
+    wait until page contains  saved
+
+Add ${number} storage levels with title ${title}
+    input text  css=.storagelevel-title  ${title}
+    input text  css=.storagelevel-number  ${number}
+    click button  Add storage levels
+    wait until page contains  saved
+
+Go to ${level2} in ${level1} of ${storageunit}
+    Go to  ${PLONEURL}/bika_setup/bika_storageunits
+    click link  ${storageunit}
+    click link  ${level1}
+    click link  ${level2}


### PR DESCRIPTION
After an order is received, each row in the products list provides two input boxes. One takes the number of items and other takes the storage level to store in.

Storage level can be selected using a fuzzy finder, which displays assignable storage levels with their hierarchy (eg. Freezer>Drawer-1>Shelf-1) and the number of available spaces in them.

On storing the products, IDs of product items are assigned to the occupied storage levels and vice versa. The number of products stored, shown in the order view, is updated accordingly.

Also, children cannot be added to a storage level which stores a product.

##### Todo
- Considering dormancy among availability criteria.
- Discarding a product item from storage.

test_InventoryOrder.robot :
```
$ bin/test -t InventoryOrder
Running bika.lims.testing.BikaTestingLayer:Robot tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.165 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.444 seconds.
  Set up bika.lims.testing.BikaTestLayer in 58.809 seconds.
  Set up plone.app.robotframework.remote.RemoteLibraryBundle:RobotRemote in 0.012 seconds.
  Set up plone.testing.z2.ZServer in 0.502 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Running:
    1/2 (50.0%)Ignored `size: undefined` at 1:9, invalid value.
[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
The following test left new threads behind:
Test order as LabManager (test_InventoryOrder.robot)
New thread(s): [<_DummyThread(Dummy-1, started daemon 140361253787392)>]
    2/2 (100.0%)Ignored `size: undefined` at 1:9, invalid value.
[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: WebDriverException: Message: u'no such session\n  (Driver info: chromedriver=2.15.322448 (52179c1b310fec1797c81ea9a20326839860b7d3),platform=Linux 3.13.0-43-generic x86_64)'
               
  Ran 2 tests with 0 failures and 0 errors in 1 minutes 42.960 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Robot in 0.000 seconds.
  Tear down plone.app.robotframework.remote.RemoteLibraryBundle:RobotRemote in 0.003 seconds.
  Tear down plone.testing.z2.ZServer in 5.026 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.011 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.059 seconds.
  Tear down plone.testing.z2.Startup in 0.008 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.003 seconds.
```
