### PR TITLE
LIMS-1397 During site import, Client Title accessor fails.

### DIFF
--- a/bika/lims/content/client.py
+++ b/bika/lims/content/client.py
@@ -131,7 +131,8 @@ class Client(Organisation):
 
     def Title(self):
         """ Return the Organisation's Name as its title """
-        return safe_unicode(self.getField('Name').get(self)).encode('utf-8')
+        name = self.schema['Name'].get(self)
+        return safe_unicode(name).encode('utf-8')
 
     security.declarePublic('getContactFromUsername')
     def getContactFromUsername(self, username):

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.9 (unreleased)
 ------------------
+LIMS-1397: Fix Client Title accessor to prevent catalog error when data is imported
 LIMS-2005: Click on Validations tab of Instruments it give error
 LIMS-1806: Instrument Interface. AQ2. Seal Analytical - Error
 LIMS-2002: Error creating Analysis Requests from batch.


### PR DESCRIPTION
The code at git@github.com:bikalabs/bika-export-import.git fixes LIMS-1397 and other issues by generalising the import/export of setupdata.  However the code has yet to be tested and integrated into bika.lims.

During this import, the existing client accessor causes cataloging to fail.  This one is identical, but works.