### PR TITLE
LIMS-1965: Modified default navtree order

### DIFF
--- a/bika/lims/profiles/default/structure/.objects
+++ b/bika/lims/profiles/default/structure/.objects
@@ -1,10 +1,10 @@
 setup-data-in-this-installation,Document
 clients,ClientFolder
-invoices,InvoiceFolder
 samples,SamplesFolder
 analysisrequests,AnalysisRequestsFolder
 batches,BatchFolder
 worksheets,WorksheetFolder
+arimports,Folder
 referencesamples,ReferenceSamplesFolder
 methods,Methods
 pricelists,PricelistFolder
@@ -12,4 +12,4 @@ supplyorders,SupplyOrderFolder
 bika_setup,BikaSetup
 reports,ReportFolder
 queries,QueryFolder
-arimports,Folder
+invoices,InvoiceFolder

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.9 (unreleased)
 ------------------
+LIMS-1965: Modified default navtree order for new installations
 LIMS-1397: Fix Client Title accessor to prevent catalog error when data is imported
 LIMS-1996: On new system with no instrument data is difficult to get going.
 LIMS-2005: Click on Validations tab of Instruments it give error


### PR DESCRIPTION
For new installations; existing order of items in Plone site root will
not be changed