### PR TITLE
LIMS-1523: Site Error when transitioning AR from 'Manage Analyses' or 'Log' tab

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -10,84 +10,24 @@ function AnalysisRequestView() {
      */
     that.load = function() {
 
-        $("#workflow-transition-prepublish").click(workflow_transition_prepublish);
-        $("#workflow-transition-publish").click(workflow_transition_publish);
-        $("#workflow-transition-republish").click(workflow_transition_republish);
-        $("#workflow-transition-receive").click(workflow_transition_receive);
-        $("#workflow-transition-retract_ar").click(workflow_transition_retract_ar);
+        // fires for all AR workflow transitions fired using the plone contentmenu workflow actions
+        $("a[id^='workflow-transition']").click(transition_with_publication_spec);
 
     }
 
-    function workflow_transition_receive(event) {
+    function transition_with_publication_spec(event) {
+        // Pass the Publication Spec UID (if present) into the WorkflowAction handler
+        // Force the transition to use the "workflow_action" url instead of content_status_modify.
+        // TODO This should be using content_status_modify!  modifying the href is silly.
         event.preventDefault();
-        var requestdata = {};
-        requestdata.workflow_action = "receive";
-        var requeststring = $.param(requestdata);
-        var href = window.location.href.split("?")[0]
-            .replace("/base_view", "")
-            .replace("/manage_results", "")
-            .replace("/workflow_action", "")
-            .replace("/view", "") + "/workflow_action?" + requeststring;
-        window.location.href = href;
+        var href = event.currentTarget.href.replace("content_status_modify", "workflow_action");
+        var element = $("#PublicationSpecification_uid");
+        if (element.length > 0) {
+            href = href + "&PublicationSpecification=" + $(element).val();
+        }
+        window.location.href = href
     }
 
-    function workflow_transition_prepublish(event){
-        event.preventDefault();
-        var requestdata = {};
-        var spec_uid = $("#PublicationSpecification_uid").val();
-        requestdata.PublicationSpecification = spec_uid;
-        requestdata.workflow_action = "prepublish";
-        var requeststring = $.param(requestdata);
-        var href = window.location.href.split("?")[0]
-            .replace("/base_view", "")
-            .replace("/manage_results", "")
-            .replace("/workflow_action", "")
-            .replace("/view", "") + "/workflow_action?" + requeststring;
-        window.location.href = href;
-    }
-
-    function workflow_transition_publish(event){
-        event.preventDefault();
-        var requestdata = {};
-        var spec_uid = $("#PublicationSpecification_uid").val();
-        requestdata.PublicationSpecification = spec_uid;
-        requestdata.workflow_action = "publish";
-        var requeststring = $.param(requestdata);
-        var href = window.location.href.split("?")[0]
-            .replace("/base_view", "")
-            .replace("/manage_results", "")
-            .replace("/workflow_action", "")
-            .replace("/view", "") + "/workflow_action?" + requeststring;
-        window.location.href = href;
-    }
-
-    function workflow_transition_republish(event){
-        event.preventDefault();
-        var requestdata = {};
-        var spec_uid = $("#PublicationSpecification_uid").val();
-        requestdata.PublicationSpecification = spec_uid;
-        requestdata.workflow_action = "republish";
-        var requeststring = $.param(requestdata);
-        var href = window.location.href.split("?")[0]
-            .replace("/base_view", "")
-            .replace("/manage_results", "")
-            .replace("/workflow_action", "")
-            .replace("/view", "") + "/workflow_action?" + requeststring;
-        window.location.href = href;
-    }
-
-    function workflow_transition_retract_ar(event) {
-        event.preventDefault();
-        var requestdata = {};
-        requestdata.workflow_action = "retract_ar";
-        var requeststring = $.param(requestdata);
-        var href = window.location.href.split("?")[0]
-            .replace("/base_view", "")
-            .replace("/manage_results", "")
-            .replace("/workflow_action", "")
-            .replace("/view", "") + "/workflow_action?" + requeststring;
-        window.location.href = href;
-    }
 }
 
 /**

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.9 (unreleased)
 ------------------
+LIMS-1523: Site Error when transitioning AR from 'Manage Analyses' or 'Log' tab
 LIMS-1397: Fix Client Title accessor to prevent catalog error when data is imported
 LIMS-1996: On new system with no instrument data is difficult to get going.
 LIMS-2005: Click on Validations tab of Instruments it give error


### PR DESCRIPTION
Refactored the URL-rewriting done when AR transitions are fired from Plone contentmenu workflow actions.

TODO This should be using content_status_modify!  modifying the href is silly.  All the WorkflowAction instances are a little redundant - this stuff should all be handled with workflow-before and workflow-after events (if possible)
