### PR TITLE
LIMS-2025: Re-enable missing barcode shortcuts

### DIFF
--- a/bika/lims/barcode.py
+++ b/bika/lims/barcode.py
@@ -1,64 +1,101 @@
 from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.WorkflowCore import WorkflowException
+
 from bika.lims.browser import BrowserView
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from bika.lims import interfaces
-from bika.lims import logger
-from bika.lims.permissions import EditResults, EditWorksheet
+from bika.lims.permissions import EditResults
+
+import json
 import plone.protect
 
+
 class barcode_entry(BrowserView):
-    """ return redirect url if the item exists
-        passes the request to catalog
+    """Decide the best redirect URL for any barcode scanned into the browser.
     """
     def __call__(self):
         try:
             plone.protect.CheckAuthenticator(self.request)
-            plone.protect.PostOnly(self.request)
         except:
-            return ""
+            return self.return_json({
+                'success': False,
+                'failure': True,
+                'error': 'Cannot verify authenticator token'})
 
+        entry = self.get_entry()
+        if not entry:
+            return self.return_json({
+                'success': False,
+                'failure': True,
+                'error': 'No barcode entry submitted'})
+
+        instance = self.resolve_item(entry)
+        if not instance:
+            return self.return_json({
+                'success': False,
+                'failure': True,
+                'error': 'Cannot resolve ID or Title: %s' % entry})
+
+        url = getattr(self, 'handle_' + instance.portal_type)(instance) \
+            if hasattr(self, 'handle_' + instance.portal_type) \
+            else instance.absolute_url()
+
+        return self.return_json({
+            'success': True,
+            'failure': False,
+            'url': url})
+
+    def get_entry(self):
+        entry = self.request.get('entry', '')
+        entry = entry.replace('*', '')
+        entry = entry.strip()
+        return entry
+
+    def resolve_item(self, entry):
+        for catalog in [self.bika_catalog, self.bika_setup_catalog]:
+            brains = catalog(title=entry)
+            if brains:
+                return brains[0].getObject()
+            brains = catalog(id=entry)
+            if brains:
+                return brains[0].getObject()
+
+    def return_json(self, value):
+        output = json.dumps(value)
+        self.request.RESPONSE.setHeader('Content-Type', 'application/json')
+        self.request.RESPONSE.write(json.dumps(output))
+        return output
+
+    def handle_AnalysisRequest(self, instance):
+        """Possible redirects for an AR.
+        - If AR is sample_due: receive it before proceeding.
+        - If AR belongs to Batch, redirect to the BatchBook view.
+        - If AR does not belong to Batch:
+            - if permission/workflow permit: go to AR manage_results.
+        - For other ARs, just redirect to the view screen.
+        """
+        # - If AR is sample_due: receive it before proceeding.
+        wf = getToolByName(self.context, 'portal_workflow')
+        if wf.getInfoFor(instance, 'review_state') == 'sample_due':
+            try:
+                wf.doActionFor(instance, 'receive')
+            except WorkflowException:
+                pass
+        # - If AR belongs to Batch, redirect to the BatchBook view.
+        batch = instance.getBatch()
+        if batch:
+            return batch.absolute_url() + "/batchbook"
+        #  - if permission/workflow permit: go to AR manage_results.
         mtool = getToolByName(self.context, 'portal_membership')
-        uc = getToolByName(self.context, 'uid_catalog')
-        entry = self.request.get("entry", '').replace("*", "")
+        if mtool.checkPermission(EditResults, instance):
+            return instance.absolute_url() + '/manage_results'
+        # - For other ARs, just redirect to the view screen.
+        return instance.absolute_url()
 
-        items = uc(UID=entry)
-        if not items:
-            return ""
-        item = items[0].getObject()
-
-        if item.portal_type == "AnalysisRequest":
-            if mtool.checkPermission(EditResults, item):
-                destination_url = item.absolute_url() + "/manage_results"
-            else:
-                destination_url = item.absolute_url()
-            return self.request.response.redirect(destination_url)
-
-        elif item.portal_type == "Sample":
-            ars = item.getAnalysisRequests()
-            if len(ars) == 1:
-                # If there's only one AR, go there
-                if mtool.checkPermission(EditResults, ars[0]):
-                    destination_url = ars[0].absolute_url() + "/manage_results"
-                else:
-                    destination_url = ars[0].absolute_url()
-                return self.request.response.redirect(destination_url)
-            else:
-                # multiple or no ARs: direct to sample.
-                destination_url = item.absolute_url()
-                return self.request.response.redirect(destination_url)
-
-        elif item.portal_type == "Worksheet":
-            if mtool.checkPermission(EditWorksheet, item):
-                destination_url = item.absolute_url()
-                return self.request.response.redirect(destination_url)
-
-        elif item.portal_type == "ReferenceSample":
-            destination_url = item.absolute_url()
-            return self.request.response.redirect(destination_url)
-
-
-"""
-Sample round/COC the user lands on the sampling round's view, if he/she is\
-authorised to see it
-"""
+    def handle_Sample(self, instance):
+        """If this sample has a single AR, go there.
+        If the sample has 0 or >1 ARs, go to the sample's view URL.
+        """
+        ars = instance.getAnalysisRequests()
+        if len(ars) == 1:
+            return self.handle_AnalysisRequest(instance)
+        else:
+            return instance.absolute_url()

--- a/bika/lims/browser/js/bika.lims.utils.barcode.js
+++ b/bika/lims/browser/js/bika.lims.utils.barcode.js
@@ -7,48 +7,6 @@ function BarcodeUtils() {
 
     that.load = function() {
 
-        // if collection gets something worth submitting,
-        // it's sent to utils.barcode_entry here.
-        function redirect(code){
-            $.ajax({
-                type: 'POST',
-                url: 'barcode_entry',
-                data: {'entry':code.replace("*",""),
-                        '_authenticator': $('input[name="_authenticator"]').val()},
-                success: function(responseText, statusText, xhr, $form) {
-                    if (responseText) {
-                        window.location.href = responseText;
-                    }
-                }
-            });
-        }
-
-        var collecting = false;
-        var code = ""
-
-        $(window).keypress(function(event) {
-            if (collecting) {
-                // short-circuit tineout when ending * is reached
-                if (event.which == "42"){
-                    collecting = false;
-                    redirect(code);
-                }
-                code = code + String.fromCharCode(event.which);
-            } else {
-                // valid barcodes will start and end with "*"
-                if (event.which == "42") {
-                    collecting = true;
-                    code = String.fromCharCode(event.which);
-                    setTimeout(function(){
-                        if(collecting == true && code != ""){
-                            collecting = false;
-                            redirect(code);
-                        }
-                    }, 500)
-                }
-            }
-        });
-
         $('.qrcode').each(function(i) {
            var code = $(this).attr('data-code');
            var size = $(this).attr('data-size');
@@ -74,3 +32,69 @@ function BarcodeUtils() {
         });
     }
 }
+
+// This function will redirect based on a barcode sequence.
+//
+// The string is sent to python, who will return a URL, which
+// we will use to set the window location.
+//
+// A barcode may begin and end with '*' but we can't make this
+// assumption about all scanners; so, we will function with a
+// 500ms timeout instead.
+
+$(document).ready(function(){
+
+    function barcode_listener() {
+
+        var that = this;
+
+        that.load = function() {
+
+            // if collection gets something worth submitting,
+            // it's sent to utils.barcode_entry here.
+            function redirect(code){
+                authenticator = $('input[name="_authenticator"]').val();
+                $.ajax({
+                    type: 'POST',
+                    url: 'barcode_entry',
+                    data: {
+                        'entry':code,
+                        '_authenticator': authenticator},
+                    success: function(responseText, statusText, xhr, $form) {
+                        if (responseText.success) {
+                            window.location.href = responseText.url;
+                        }
+                    }
+                });
+            }
+
+            var collecting = false;
+            var code = ""
+
+            $(window).keypress(function(event) {
+                // We do not want keypresses that were sent to input or textarea
+                if(event.target.tagName == "BODY"){
+                    if (collecting) {
+                        code = code + String.fromCharCode(event.which);
+                    } else {
+                        collecting = true;
+                        code = String.fromCharCode(event.which);
+                        setTimeout(function(){
+                            collecting = false;
+                            if (code.length > 2){
+                                redirect(code);
+                            }
+                        }, 500)
+                    }
+                }
+            });
+        }
+    }
+
+    // immediately load the barcode_listener so that barcode entries are detected
+    // in all windows (when there is no input element selected).
+    window.bika = window.bika || { lims: {} };
+    window.bika.lims['barcode_listener'] = new barcode_listener();
+    window.bika.lims['barcode_listener'].load();
+
+});

--- a/bika/lims/tests/test_barcode_entry.py
+++ b/bika/lims/tests/test_barcode_entry.py
@@ -1,0 +1,136 @@
+from Products.CMFPlone.utils import _createObjectByType
+from bika.lims.testing import BIKA_SIMPLE_FIXTURE
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.utils import tmpID, changeWorkflowState
+from plone.app.testing import login
+from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
+from bika.lims.barcode import barcode_entry
+from DateTime import DateTime
+
+import json
+import transaction
+
+try:
+    import unittest2 as unittest
+except ImportError:  # Python 2.7
+    import unittest
+
+
+class TestBarcodeEntry(BikaFunctionalTestCase):
+    layer = BIKA_SIMPLE_FIXTURE
+
+    def addthing(self, folder, portal_type, **kwargs):
+        thing = _createObjectByType(portal_type, folder, tmpID())
+        thing.unmarkCreationFlag()
+        thing.edit(**kwargs)
+        thing._renameAfterCreation()
+        return thing
+
+    def setUp(self):
+        super(TestBarcodeEntry, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+        clients = self.portal.clients
+        bs = self.portal.bika_setup
+        # @formatter:off
+        self.client = self.addthing(clients, 'Client', title='Happy Hills', ClientID='HH')
+        contact = self.addthing(self.client, 'Contact', Firstname='Rita', Lastname='Mohale')
+        container = self.addthing(bs.bika_containers, 'Container', title='Bottle', capacity="10ml")
+        sampletype = self.addthing(bs.bika_sampletypes, 'SampleType', title='Water', Prefix='H2O')
+        samplepoint = self.addthing(bs.bika_samplepoints, 'SamplePoint', title='Toilet')
+        priority = self.addthing(bs.bika_arpriorities, 'ARPriority', title='Normal', sortKey=1)
+        service = self.addthing(bs.bika_analysisservices, 'AnalysisService', title='Ecoli', Keyword="ECO")
+        batch = self.addthing(self.portal.batches, 'Batch', title='B1')
+        # Create Sample with single partition
+        self.sample1 = self.addthing(self.client, 'Sample', SampleType=sampletype)
+        self.sample2 = self.addthing(self.client, 'Sample', SampleType=sampletype)
+        self.addthing(self.sample1, 'SamplePartition', Container=container)
+        self.addthing(self.sample2, 'SamplePartition', Container=container)
+        # Create an AR
+        self.ar1 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
+                                Sample=self.sample1, Analyses=[service], SamplingDate=DateTime())
+        # Create a secondary AR - linked to a Batch
+        self.ar2 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
+                                Sample=self.sample1, Analyses=[service], SamplingDate=DateTime(),
+                                Batch=batch)
+        # Create an AR - single AR on sample2
+        self.ar3 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
+                                Sample=self.sample2, Analyses=[service], SamplingDate=DateTime())
+        # @formatter:on
+        wf = getToolByName(self.portal, 'portal_workflow')
+        for ar in self.ar1, self.ar2, self.ar3:
+            # Set initial AR state
+            wf.doActionFor(ar, 'no_sampling_workflow')
+
+        transaction.commit()
+
+    def tearDown(self):
+        super(TestBarcodeEntry, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+
+    def test_ar_states_without_batch(self):
+        wf = getToolByName(self.portal, 'portal_workflow')
+        self.portal.REQUEST['entry'] = self.ar1.id
+        self.portal.REQUEST['_authenticator'] = self.getAuthenticator()
+
+        value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+        if value.get('failure', False):
+            self.fail('failure code in json return: ' + value['error'])
+        state = wf.getInfoFor(self.ar1, 'review_state')
+        self.assertTrue(state == 'sample_received',
+                        'AR is in %s state; should be sample_received' % state)
+
+        value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+        if value.get('failure', False):
+            self.fail('failure code in json return: ' + value['error'])
+        expected = self.ar1.absolute_url() + "/manage_results"
+        self.assertEqual(value['url'], expected,
+                         "AR redirect should be  %s but it's %s" % (
+                             expected, value['url']))
+
+        changeWorkflowState(self.ar1, 'bika_ar_workflow', 'verified')
+        wf.getWorkflowById('bika_ar_workflow').updateRoleMappingsFor(self.ar1)
+        self.ar1.reindexObject(idxs=['allowedRolesAndUsers'])
+
+        value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+        if value.get('failure', False):
+            self.fail('failure code in json return: ' + value['error'])
+        expected = self.ar1.absolute_url()
+        self.assertEqual(value['url'], expected,
+                         "AR redirect should be  %s but it's %s" % (
+                             expected, value['url']))
+
+    def test_batchbook_view(self):
+        self.portal.REQUEST['entry'] = self.ar2.id
+        self.portal.REQUEST['_authenticator'] = self.getAuthenticator()
+        value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+        expected = self.ar2.getBatch().absolute_url() + "/batchbook"
+        self.assertEqual(value['url'], expected,
+                         "AR redirect should be batchbook %s but it's %s" % (
+                             expected, value['url']))
+
+    def test_sample_with_multiple_ars_redirects_to_self(self):
+        self.portal.REQUEST['entry'] = self.sample1.id
+        self.portal.REQUEST['_authenticator'] = self.getAuthenticator()
+        value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+        expected = self.sample1.absolute_url()
+        self.assertEqual(value['url'], expected,
+                         "sample1 redirect should be self:%s but it's %s" % (
+                             expected, value['url']))
+
+
+def test_sample_with_single_ar_redirects_to_AR(self):
+    self.portal.REQUEST['entry'] = self.sample2.id
+    self.portal.REQUEST['_authenticator'] = self.getAuthenticator()
+    value = json.loads(barcode_entry(self.portal, self.portal.REQUEST)())
+    expected = self.ar3.absolute_url()
+    self.assertEqual(value['url'], expected,
+                     "sample2 redirect should be ar3:%s but it's %s" % (
+                         expected, value['url']))
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestBarcodeEntry))
+    suite.layer = BIKA_SIMPLE_FIXTURE
+    return suite


### PR DESCRIPTION
Recognises title and ID of objects in bika_catalog / bika_setup_catalog

If an AR is scanned:
    If it's attached to a Batch: redirect to Batch/batchbook view
    If EditResults permission is available: redirect to manage_results
    else: redirect to AR view screen.

If a Sample is scanned:
    If the sample has a single AR:  delegate to AR logic above.
    If sample has multipel ARs: redirect to Sample view screen.

All other recognised objects: redirect to object view screen.

---------

campbell ~/Plone/zeocluster $ bin/test -m bika.lims -t barcode
Running bika.lims.testing.BikaSimple:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.180 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.162 seconds.
  Set up bika.lims.testing.SimpleTestLayer in 10.795 seconds.
  Set up bika.lims.testing.BikaSimple:Functional in 0.000 seconds.
  Ran 3 tests with 0 failures and 0 errors in 9.170 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaSimple:Functional in 0.000 seconds.
  Tear down bika.lims.testing.SimpleTestLayer in 0.006 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.052 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.003 seconds.
