### PR TITLE
Fix the method in charge of checking if instrument is valid

### DIFF
--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -360,8 +360,8 @@ class Instrument(ATFolder):
         return self.isOutOfDate() == False \
                 and self.isQCValid() == True \
                 and self.getDisposeUntilNextCalibrationTest() == False \
-                and self.isValidationInProgress == False \
-                and self.isCalibrationInProgress == False \
+                and self.isValidationInProgress() == False \
+                and self.isCalibrationInProgress() == False
 
     def getLatestReferenceAnalyses(self):
         """ Returns a list with the latest Reference analyses performed

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.8.2 (2015-09-23)
 --------------------
+LIMS-1996: On new system with no instrument data is difficult to get going.
 LIMS-1760: Customised AR Import spreadsheets (refactored, support importing to Batch)
 LIMS-1930: AssertionError: Having an orphan size, higher than batch size is undefined
 LIMS-1818: Instrument Interface. Eltra CS-2000


### PR DESCRIPTION
Fixes [LIMS-2038 Catch 22. Cannot capture calibration results for uncalibrated instrument. Missed something, still... help please](https://jira.bikalabs.com/browse/LIMS-2038)
Fixed earlier in 319: [ LIMS-1996: On new system with no instrument data it is difficult to get going. The warnings could be confusing](https://jira.bikalabs.com/browse/LIMS-1996), PR https://github.com/bikalabs/Bika-LIMS/pull/1611