### PR TITLE
LIMS-1928 -> Roll-back

### DIFF
--- a/bika/lims/content/instrumentcalibration.py
+++ b/bika/lims/content/instrumentcalibration.py
@@ -116,7 +116,7 @@ schema = BikaSchema.copy() + Schema((
 
 ))
 
-schema['title'].widget.label = 'Asset Number'
+schema['title'].widget.label = 'Task ID'
 
 
 class InstrumentCalibration(BaseFolder):
@@ -124,7 +124,7 @@ class InstrumentCalibration(BaseFolder):
     schema = schema
     displayContentsTab = False
 
-    _at_rename_after_creation = True
+    _at_rename_after_creation = False
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)

--- a/bika/lims/content/instrumentcertification.py
+++ b/bika/lims/content/instrumentcertification.py
@@ -11,13 +11,11 @@ from Products.CMFCore import permissions
 
 schema = BikaSchema.copy() + Schema((
 
-    ComputedField('AssetNumber',
-        expression='here.getInstrumentAssetNumber()',
-        widget=ComputedWidget(
-            label=_('Instrument Asset Number'),
-            visible=True,
-            description=_("Instrument's Asset Number")
-         )
+    StringField('TaskID',
+        widget = StringWidget(
+            label=_("Task ID"),
+            description=_("The instrument's ID in the lab's asset register"),
+        )
     ),
 
     ReferenceField('Instrument',
@@ -158,12 +156,5 @@ class InstrumentCertification(BaseFolder):
                            sort_on='sortable_title'):
             pairs.append((contact.UID, contact.Title))
         return DisplayList(pairs)
-
-    def getInstrumentAssetNumber(self):
-        """
-        Obtains the instrument's asset number
-        :return: The asset number string
-        """
-        return self.aq_parent.getAssetNumber() if self.aq_parent.getAssetNumber() else ''
 
 atapi.registerType(InstrumentCertification, PROJECTNAME)

--- a/bika/lims/content/instrumentvalidation.py
+++ b/bika/lims/content/instrumentvalidation.py
@@ -101,14 +101,14 @@ schema = BikaSchema.copy() + Schema((
 
 ))
 
-schema['title'].widget.label = 'Asset Number'
+schema['title'].widget.label = 'Task ID'
 
 class InstrumentValidation(BaseFolder):
     security = ClassSecurityInfo()
     schema = schema
     displayContentsTab = False
 
-    _at_rename_after_creation = True
+    _at_rename_after_creation = False
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)

--- a/bika/lims/profiles/default/types/InstrumentValidation.xml
+++ b/bika/lims/profiles/default/types/InstrumentValidation.xml
@@ -4,7 +4,7 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="plone"
         purge="True">
- <property name="title">InstrumentValidation</property>
+ <property name="title">Instrument Validation</property>
  <property name="description"></property>
  <property name="content_icon">++resource++bika.lims.images/instrumentvalidation.png</property>
  <property name="content_meta_type">InstrumentValidation</property>


### PR DESCRIPTION
https://jira.bikalabs.com/browse/LIMS-1928
From IRC:
<lemoene> Initially i thought the i strument's Asset number should go into those fields
<lemoene> but it was tagged incorrectly as 'Asset number' while it actually referes to the Calibration's 'Task ID'
<lemoene> please thus ignore my initial request that the field needs to auto poulate with the instrument's asset number. roll that back plaes
<lemoene> and 2. Just modify the field's tag to read 'Task ID'
<lemoene> dis that make sense pau?
<pau> ok, we are talking about instrument certificate then
<pau> yes, i'll do a roll-back
<lemoene> 2 of those tabs has the same issue. checking...
<lemoene> 3: Add Calibration Certificate AND Add Instrument Calibration Add Instrument Validation. Titles might have changed since
<lemoene> 3: Add Calibration Certificate AND Add Instrument Calibration AND Add Instrument Validation.
<lemoene> urls /portal_factory/InstrumentCertification/instrumentcertification; /portal_factory/InstrumentValidation/instrumentvalidation; portal_factory/InstrumentCalibration/instrumentcalibration