### PR TITLE
LIMS-1832 New Results Template, COA. Multiple ARs in columns

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -148,6 +148,10 @@ class AnalysisRequestPublishView(BrowserView):
                 content = content_file.read()
         return content
 
+    def isSingleARTemplate(self):
+        seltemplate = self.request.form.get('template', self._DEFAULT_TEMPLATE)
+        return not seltemplate.lower().startswith('multi')
+
     def isQCAnalysesVisible(self):
         """ Returns if the QC Analyses must be displayed
         """

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -34,7 +34,9 @@ import urllib2
 class AnalysisRequestPublishView(BrowserView):
     template = ViewPageTemplateFile("templates/analysisrequest_publish.pt")
     _ars = []
+    _arsbyclient = []
     _current_ar_index = 0
+    _current_arsbyclient_index = 0
     _publish = False
 
     def __init__(self, context, request, publish=False):
@@ -61,6 +63,16 @@ class AnalysisRequestPublishView(BrowserView):
             self.destination_url = self.request.get_header("referer",
                                    self.context.absolute_url())
 
+        # Group ARs by client
+        groups = {}
+        for ar in self._ars:
+            idclient = ar.aq_parent.id
+            if idclient not in groups:
+                groups[idclient] = [ar]
+            else:
+                groups[idclient].append(ar)
+        self._arsbyclient = [group for group in groups.values()]
+
         # Do publish?
         if self.request.form.get('publish', '0') == '1':
             self.publishFromPOST()
@@ -81,22 +93,35 @@ class AnalysisRequestPublishView(BrowserView):
     def getAnalysisRequests(self):
         """ Returns a dict with the analysis requests to manage
         """
-        return self._ars;
+        return self._ars
 
     def getAnalysisRequestsCount(self):
         """ Returns the number of analysis requests to manage
         """
-        return len(self._ars);
+        return len(self._ars)
+
+    def getGroupedAnalysisRequestsCount(self):
+        """ Returns the number of groups of analysis requests to manage when
+            a multi-ar template is selected. The ARs are grouped by client
+        """
+        return len(self._arsbyclient)
 
     def getAnalysisRequestObj(self):
         """ Returns the analysis request objects to be managed
         """
         return self._ars[self._current_ar_index]
 
-    def getAnalysisRequest(self):
-        """ Returns the dict for the currently managed analysis request
+    def getAnalysisRequest(self, analysisrequest=None):
+        """ Returns the dict for the Analysis Request specified. If no AR set,
+            returns the current analysis request
         """
-        return self._ar_data(self._ars[self._current_ar_index])
+        return self._ar_data(analysisrequest) if analysisrequest \
+                else self._ar_data(self._ars[self._current_ar_index])
+
+    def getAnalysisRequestGroup(self):
+        """ Returns the current analysis request group to be managed
+        """
+        return self._arsbyclient[self._current_arsbyclient_index]
 
     def _nextAnalysisRequest(self):
         """ Move to the next analysis request
@@ -104,10 +129,15 @@ class AnalysisRequestPublishView(BrowserView):
         if self._current_ar_index < len(self._ars):
             self._current_ar_index += 1
 
-    def getReportTemplate(self):
-        """ Returns the html template for the current ar and moves to
-            the next ar to be processed. Uses the selected template
-            specified in the request ('template' parameter)
+    def _nextAnalysisRequestGroup(self):
+        """ Move to the next analysis request group
+        """
+        if self._current_arsbyclient_index < len(self._arsbyclient):
+            self._current_arsbyclient_index += 1
+
+    def _renderTemplate(self):
+        """ Returns the html template to be rendered in accordance with the
+            template specified in the request ('template' parameter)
         """
         templates_dir = 'templates/reports'
         embedt = self.request.form.get('template', self._DEFAULT_TEMPLATE)
@@ -116,14 +146,37 @@ class AnalysisRequestPublishView(BrowserView):
             templates_dir = queryResourceDirectory('reports', prefix).directory
             embedt = template
         embed = ViewPageTemplateFile(os.path.join(templates_dir, embedt))
+        return embedt, embed(self)
+
+    def getReportTemplate(self):
+        """ Returns the html template for the current ar and moves to
+            the next ar to be processed. Uses the selected template
+            specified in the request ('template' parameter)
+        """
         reptemplate = ""
+        embedt = ""
         try:
-            reptemplate = embed(self)
+            embedt, reptemplate = self._renderTemplate()
         except:
             tbex = traceback.format_exc()
             arid = self._ars[self._current_ar_index].id
             reptemplate = "<div class='error-report'>%s - %s '%s':<pre>%s</pre></div>" % (arid, _("Unable to load the template"), embedt, tbex)
         self._nextAnalysisRequest()
+        return reptemplate
+
+    def getGroupedReportTemplate(self):
+        """ Returns the html template for the current group of ARs and moves to
+            the next group to be processed. Uses the selected template
+            specified in the request ('template' parameter)
+        """
+        reptemplate = ""
+        embedt = ""
+        try:
+            embedt, reptemplate = self._renderTemplate()
+        except:
+            tbex = traceback.format_exc()
+            reptemplate = "<div class='error-report'>%s '%s':<pre>%s</pre></div>" % (_("Unable to load the template"), embedt, tbex)
+        self._nextAnalysisRequestGroup()
         return reptemplate
 
     def getReportStyle(self):
@@ -945,3 +998,52 @@ class AnalysisRequestPublishView(BrowserView):
         else:
             subject = t(_('Analysis results'))
         return subject, tot_line
+
+    def getAnaysisBasedTransposedMatrix(self, ars):
+        """ Returns a dict with the following structure:
+            {'category_1_name':
+                {'service_1_title':
+                    {'service_1_uid':
+                        {'service': <AnalysisService-1>,
+                         'ars': {'ar1_id': [<Analysis (for as-1)>,
+                                           <Analysis (for as-1)>],
+                                 'ar2_id': [<Analysis (for as-1)>]
+                                },
+                        },
+                    },
+                {'service_2_title':
+                     {'service_2_uid':
+                        {'service': <AnalysisService-2>,
+                         'ars': {'ar1_id': [<Analysis (for as-2)>,
+                                           <Analysis (for as-2)>],
+                                 'ar2_id': [<Analysis (for as-2)>]
+                                },
+                        },
+                    },
+                ...
+                },
+            }
+        """
+        analyses = {}
+        for ar in ars:
+            ans = [an.getObject() for an in ar.getAnalyses()]
+            for an in ans:
+                service = an.getService()
+                cat = service.getCategoryTitle()
+                if cat not in analyses:
+                    analyses[cat] = {
+                        service.title: {
+                            'service': service,
+                            'ars': {ar.id: an.getFormattedResult()}
+                        }
+                    }
+                elif service.title not in analyses[cat]:
+                    analyses[cat][service.title] = {
+                        'service': service,
+                        'ars': {ar.id: an.getFormattedResult()}
+                    }
+                else:
+                    d = analyses[cat][service.title]
+                    d['ars'][ar.id] = an.getFormattedResult()
+                    analyses[cat][service.title]=d
+        return analyses

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -233,14 +233,16 @@
             tal:content='structure python:view.getReportTemplate()'></div>
         </tal:ar>
         </tal:singlearreport>
-          
+
         <tal:multiarreport condition="python:not view.isSingleARTemplate()">
         <!--
           Multi-AR template. ARs grouped by client.
           The templates from this type must be able to render multiples ARs, so
           each report will contain a bunch of ARs from the same client
         -->
-          Load here the multi-AR template
+        <tal:argroup tal:repeat="i python:range(view.getGroupedAnalysisRequestsCount())">
+        <div tal:content='structure python:view.getGroupedReportTemplate()'></div>
+        </tal:argroup>
         </tal:multiarreport>
         </div>
     </div>

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -220,12 +220,28 @@
             }
         </style>
         <div id='report'>
+
+        <tal:singlearreport condition="python:view.isSingleARTemplate()">
+        <!-- Single-AR template.
+          The templates from this type will render one AR at a time, so one
+          report per AR will be generated.
+        -->
         <tal:ar tal:repeat="i python:range(view.getAnalysisRequestsCount())">
         <div tal:attributes="id python:view.getAnalysisRequestObj().id;
                             uid python:view.getAnalysisRequestObj().UID();
                             class python:('ar_publish_body%s' % (' ar-invalid' if view.getAnalysisRequestObj().isInvalid() else (' ar-provisional' if view.getAnalysisRequest()['prepublish']==True else '')))"
             tal:content='structure python:view.getReportTemplate()'></div>
         </tal:ar>
+        </tal:singlearreport>
+          
+        <tal:multiarreport condition="python:not view.isSingleARTemplate()">
+        <!--
+          Multi-AR template. ARs grouped by client.
+          The templates from this type must be able to render multiples ARs, so
+          each report will contain a bunch of ARs from the same client
+        -->
+          Load here the multi-AR template
+        </tal:multiarreport>
         </div>
     </div>
     <div id="my_mm" style="height:1mm;display:none"></div>

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
@@ -1,0 +1,196 @@
+/* IMPORTANT NOTE
+ * Do not use margins, use padding instead
+ */
+
+#report {
+    font: 9pt Arial, Verdana, serif;
+}
+
+#report h1 { font-size:1.4em; }
+#report h2 { font-size:1.2em; }
+#report h3 { font-size:1.1em; }
+
+#report h1,
+#report h2,
+#report h3 {
+    font-weight:bold;
+    padding-bottom:5px !important;
+}
+
+#report table {
+    width: 100%;
+}
+
+#report table tr td,
+#report table tr th {
+    text-align:left;
+    vertical-align:top;
+}
+#report .label {
+    font-weight:bold;
+    padding-right: 10px;
+}
+#report .outofrange,
+#report .outofrange a {
+    font-weight:bold;
+    color:#d40000;
+}
+#report .units,
+#report .units sub,
+#report .units sup {
+    color:#777;
+    font-weight:normal;
+    font-style:italic;
+}
+#report .units sub,
+#report .units sup {
+    font-size:7pt;
+}
+
+#report table#section-header{
+    border-bottom:1px solid #000;
+}
+
+#report table#section-header,
+#report table#section-info {
+    
+}
+#report table#section-header td#accreditation-logo {
+    width:80mm;
+}
+#report table#section-info td#lab-info {
+    width:80mm;
+}
+#report #section-alert {
+    padding:20px;
+    border:1px solid #CDCDCD;
+    background-color:#ffffff;
+    margin:0px;
+}
+#report #section-alert h1 {
+    font-size:1em;
+    margin:0px;
+    padding:0;
+    border:none;
+    color:#d40000;
+}
+#report #section-results,
+#report #section-qcresults,
+#report #section-resultsinterpretation {
+    padding-top:20px;
+}
+#report #section-summary table tr td,
+#report #section-results table tr td,
+#report #section-qcresults table tr td {
+    padding-left:5px;
+}
+#report #section-summary tr td {
+    border-left-width: 0px;
+    border-bottom:1px solid #ccc;
+}
+#report #section-summary tr td.label {
+    width:60mm;
+}
+#report #section-results table thead tr th,
+#report #section-qcresults table thead tr th {
+    padding-right:10px;
+}
+#report #section-results table thead tr th span,
+#report #section-qcresults table thead tr th span {
+    display:block;
+    border-bottom:1px solid #000;
+    line-height:1.6;
+}
+#report #section-results .result {
+    width:100px;
+}
+#report #section-results .specs {
+    width:200px;
+    text-align:center;
+    padding-right:10px;
+}
+#report #section-results .outofrange {
+    width:10px;
+}
+#report #section-results .remarks {
+    font-size: 0.9em;
+    padding: 0 400px 15px 3px;
+    color: #555;
+}
+#report #section-qcresults .result {
+    width:60px;
+}
+#report #section-qcresults .specs {
+    width:100px;
+    text-align:center;
+    padding-right:10px;
+}
+#report #section-qcresults .worksheet {
+    width:80px;
+}
+#report #section-qcresults .refsample {
+    width:200px;
+}
+#report #section-qcresults .outofrange {
+    width:10px;
+}
+
+#report #section-attachments ul {
+    list-style-type:none;
+    margin:0px;
+    padding:0px;
+    margin-bottom:20px;
+}
+#report #section-attachments table#analysis-attachments td {
+    padding-right:20px;
+}
+#report #section-signatures {
+    padding:10mm 0 5mm;
+}
+#section-discreeter {
+    color:#444;
+}
+#section-discreeter * {
+    font-size:0.9em;
+}
+#section-discreeter ol {
+    margin:0;
+    padding: 0 0 0 15px;
+}
+#report .page-footer .barcode-container {
+    text-align:right;
+}
+#report .barcode {
+    float: right;
+}
+#report #ariddept {
+    font-size: 10px;
+    overflow: auto;
+    padding: 0 10px 5px;
+    text-align: right;
+}
+#report div#section-info td {
+    vertical-align: top;
+}
+#report div#section-info td a {
+    text-decoration: none;
+}
+#report div#section-info table {
+    width: 100%;
+}
+#report img.accredited-ico {
+    vertical-align:bottom;
+    padding-right:5px;
+}
+#report .category_comments {
+    color: #333;
+    font-size: 11px;
+    line-height: 130%;
+    padding: 10px 15px 15px;
+}
+
+#report .page-footer table {
+    border-top: 1px solid #aaaaaa;
+    padding: 5px 0;
+    width: 100%;
+}

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
@@ -46,155 +46,14 @@
 #report .units sup {
     font-size:7pt;
 }
-
-#report table#section-header{
-    border-bottom:1px solid #000;
-}
-
-#report table#section-header,
-#report table#section-info {
-
-}
-#report table#section-header td#accreditation-logo {
-    width:80mm;
-}
-#report table#section-info td#lab-info {
-    width:80mm;
-}
-#report #section-alert {
-    padding:20px;
-    border:1px solid #CDCDCD;
-    background-color:#ffffff;
-    margin:0px;
-}
-#report #section-alert h1 {
-    font-size:1em;
-    margin:0px;
-    padding:0;
-    border:none;
-    color:#d40000;
-}
-#report #section-results,
-#report #section-qcresults,
-#report #section-resultsinterpretation {
-    padding-top:20px;
-}
-#report #section-summary table tr td,
-#report #section-results table tr td,
-#report #section-qcresults table tr td {
-    padding-left:5px;
-}
-#report #section-summary tr td {
-    border-left-width: 0px;
-    border-bottom:1px solid #ccc;
-}
-#report #section-summary tr td.label {
-    width:60mm;
-}
-#report #section-results table thead tr th,
-#report #section-qcresults table thead tr th {
-    padding-right:10px;
-}
-#report #section-results table thead tr th span,
-#report #section-qcresults table thead tr th span {
-    display:block;
-    border-bottom:1px solid #000;
-    line-height:1.6;
-}
-#report #section-results .result {
-    width:100px;
-}
-#report #section-results .specs {
-    width:200px;
-    text-align:center;
-    padding-right:10px;
-}
-#report #section-results .outofrange {
-    width:10px;
-}
-#report #section-results .remarks {
-    font-size: 0.9em;
-    padding: 0 400px 15px 3px;
-    color: #555;
-}
-#report #section-qcresults .result {
-    width:60px;
-}
-#report #section-qcresults .specs {
-    width:100px;
-    text-align:center;
-    padding-right:10px;
-}
-#report #section-qcresults .worksheet {
-    width:80px;
-}
-#report #section-qcresults .refsample {
-    width:200px;
-}
-#report #section-qcresults .outofrange {
-    width:10px;
-}
-
-#report #section-attachments ul {
-    list-style-type:none;
-    margin:0px;
-    padding:0px;
-    margin-bottom:20px;
-}
-#report #section-attachments table#analysis-attachments td {
-    padding-right:20px;
-}
-#report #section-signatures {
-    padding:10mm 0 5mm;
-}
-#section-discreeter {
-    color:#444;
-}
-#section-discreeter * {
-    font-size:0.9em;
-}
-#section-discreeter ol {
-    margin:0;
-    padding: 0 0 0 15px;
-}
-#report .page-footer .barcode-container {
-    text-align:right;
-}
-#report .barcode {
-    float: right;
-}
-#report #ariddept {
-    font-size: 10px;
-    overflow: auto;
-    padding: 0 10px 5px;
-    text-align: right;
-}
-#report div#section-info td {
-    vertical-align: top;
-}
-#report div#section-info td a {
-    text-decoration: none;
-}
-#report div#section-info table {
-    width: 100%;
-}
-#report img.accredited-ico {
-    vertical-align:bottom;
-    padding-right:5px;
-}
-#report .category_comments {
-    color: #333;
-    font-size: 11px;
-    line-height: 130%;
-    padding: 10px 15px 15px;
-}
-
 #report .page-footer table {
     border-top: 1px solid #aaaaaa;
     padding: 5px 0;
     width: 100%;
 }
-
+#report #ar-grid th {
+    padding: 5px 5px 5px 0;
+}
 #report #ar-grid td {
   border:1px solid #cdcdcd;
   padding:3px;
@@ -202,4 +61,14 @@
 #report #ar-grid td.blank-row {
   border: 0 none;
   padding: 10px;
+}
+#report #ar-grid td.sampleid,
+#report #ar-grid td.sampletype,
+#report #ar-grid td.samplepoint,
+#report #ar-grid td.result {
+  text-align:center;
+}
+#report #ar-grid td.sampleid {
+  font-weight:bold;
+  text-align:center;
 }

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
@@ -53,7 +53,7 @@
 
 #report table#section-header,
 #report table#section-info {
-    
+
 }
 #report table#section-header td#accreditation-logo {
     width:80mm;
@@ -193,4 +193,13 @@
     border-top: 1px solid #aaaaaa;
     padding: 5px 0;
     width: 100%;
+}
+
+#report #ar-grid td {
+  border:1px solid #cdcdcd;
+  padding:3px;
+}
+#report #ar-grid td.blank-row {
+  border: 0 none;
+  padding: 10px;
 }

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
@@ -108,22 +108,24 @@
       <tr>
         <th i18n:translate="" colspan="5">Sample ID</th>
         <tal:ar repeat="ar ars">
-        <td tal:content="python:ar.getSample().id"
-            tal:attributes="id ar/id;uid ar/UID;"></td>
+        <td tal:attributes="id ar/id;uid ar/UID;" class="sampleid">
+          <a tal:attributes="href python:ar.getSample().absolute_url()"
+             tal:content="python:ar.getSample().id"></a>
+        </td>
         </tal:ar>
       </tr>
       <!-- Sample Type -->
       <tr>
         <th i18n:translate="" colspan="5">Sample Type</th>
         <tal:ar repeat="ar ars">
-        <td tal:content="python:ar.getSample().getSampleType().title"></td>
+        <td class="sampletype" tal:content="python:ar.getSample().getSampleType().title"></td>
         </tal:ar>
       </tr>
       <!-- Sample Point -->
       <tr>
         <th i18n:translate="" colspan="5">Sample Point</th>
         <tal:ar repeat="ar ars">
-        <td tal:content="python:ar.getSample().getSamplePointTitle()"></td>
+        <td class="samplepoint" tal:content="python:ar.getSample().getSamplePointTitle()"></td>
         </tal:ar>
       </tr>
 
@@ -141,15 +143,15 @@
       </tr>
       <tal:cats repeat="cat python:sorted(transposed.keys())">
       <tr>
-        <td tal:content="cat" tal:attributes="rowspan python:len(transposed[cat].keys())+1"></td>
+        <td class="category" tal:content="cat" tal:attributes="rowspan python:len(transposed[cat].keys())+1"></td>
       </tr>
       <tr tal:repeat="service python:sorted(transposed[cat].keys())">
-        <td tal:content="service"></td>
+        <td class="service" tal:content="service"></td>
         <td></td>
-        <td tal:content="python:transposed[cat][service]['service'].getUnit()"></td>
-        <td tal:content="python:transposed[cat][service]['service'].getMethod().title if transposed[cat][service]['service'].getMethod() else ''"></td>
+        <td class="unit" tal:content="python:transposed[cat][service]['service'].getUnit()"></td>
+        <td class="method" tal:content="python:transposed[cat][service]['service'].getMethod().title if transposed[cat][service]['service'].getMethod() else ''"></td>
         <tal:ar repeat="ar ars">
-        <td tal:content="python:transposed[cat][service]['ars'].get(ar.id,'')"></td>
+        <td class="result" tal:content="python:transposed[cat][service]['ars'].get(ar.id,'')"></td>
         </tal:ar>
       </tr>
       </tal:cats>

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
@@ -1,0 +1,91 @@
+<!--
+    Default Analysis Request results template for Bika LIMS
+
+    All data is available using the analysisrequest dictionary.
+    Example for accessing and displaying data:
+
+    <p tal:content="python:analysisrequest['laboratory']['title']"></p>
+
+    or
+
+    <p tal:content="analysisrequest/laboratory/title"></p>
+
+    Take a look to the documentation for more information about
+    available data and fields.
+    https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates
+
+-->
+<tal:report tal:define="argroup python:view.getAnalysisRequestGroup();
+                        analysisrequest python:argroup[0];
+                        client          analysisrequest/client;
+                        contact         analysisrequest/contact;
+                        laboratory      analysisrequest/laboratory;
+                        portal          analysisrequest/portal;
+                        sample          analysisrequest/sample;
+                        batch           analysisrequest/batch;
+                        analyses        analysisrequest/analyses;
+                        qcanalyses      analysisrequest/qcanalyses;
+                        specifications  analysisrequest/specifications;
+                        reporter        analysisrequest/reporter;
+                        pointsofcapture analysisrequest/points_of_capture;
+                        categories      analysisrequest/categories;
+                        deptanalyses    analysisrequest/department_analyses;
+                        categqcanalyses analysisrequest/categorized_qcanalyses;
+                        hasqcanalyses   python:len(qcanalyses) &gt; 0;
+                        reportdrymatter analysisrequest/report_drymatter;
+                        hasprevresults  analysisrequest/haspreviousresults;
+                        showqcanalyses  python:view.isQCAnalysesVisible();
+                        remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
+
+<!--
+    Page Header
+    A div element with the class "page-header" will be placed on the
+    top of the report, within the top margin area. This element
+    will be displayed on each page.
+
+    Page numbering
+    For the number of page, use the "page-current-num" class.
+    For the total count, use the "page-total-count" class.
+-->
+<div id="section-header" class='page-header'>
+    <div id='lab-logo'>
+        <a tal:attributes="href laboratory/url">
+            <img tal:attributes="src laboratory/logo"/>
+        </a>
+    </div>
+</div>
+
+<tal:ar tal:repeat="ar angroup">
+  <div tal:content="ar/id"></div>
+</tal:ar>
+
+<!--
+    Page footer
+    A div element with the class "page-footer" will be placed in the
+    bottom of the report, within the bottom margin area. This element
+    will be displayed on each page.
+
+    Page numbering
+    For the number of page, use the "page-current-num" class.
+    For the total count, use the "page-total-count" class.
+-->
+<div class='page-footer'>
+    <table>
+        <tr>
+            <td class='footer-discreeter'>
+                <div class="page-number">Page <span class="page-current-num"></span> of <span class="page-total-count"></span></div>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<!--
+    Manual break ("manual-page-break" css class)
+    We want to report to be splitted by departments.
+
+    Restart page count ("restart-page-count" css class)
+    We want the number of pages to restart after the current page
+-->
+<div class='manual-page-break restart-page-count'></div>
+
+</tal:report>

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
@@ -15,77 +15,176 @@
     https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates
 
 -->
-<tal:report tal:define="argroup python:view.getAnalysisRequestGroup();
-                        analysisrequest python:argroup[0];
-                        client          analysisrequest/client;
-                        contact         analysisrequest/contact;
-                        laboratory      analysisrequest/laboratory;
-                        portal          analysisrequest/portal;
-                        sample          analysisrequest/sample;
-                        batch           analysisrequest/batch;
-                        analyses        analysisrequest/analyses;
-                        qcanalyses      analysisrequest/qcanalyses;
-                        specifications  analysisrequest/specifications;
-                        reporter        analysisrequest/reporter;
-                        pointsofcapture analysisrequest/points_of_capture;
-                        categories      analysisrequest/categories;
-                        deptanalyses    analysisrequest/department_analyses;
-                        categqcanalyses analysisrequest/categorized_qcanalyses;
-                        hasqcanalyses   python:len(qcanalyses) &gt; 0;
-                        reportdrymatter analysisrequest/report_drymatter;
-                        hasprevresults  analysisrequest/haspreviousresults;
-                        showqcanalyses  python:view.isQCAnalysesVisible();
-                        remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
+<tal:report tal:define="num_ars_per_page python:4;
+                        argroup python:view.getAnalysisRequestGroup();
+                        arspage python:[argroup[i:i+num_ars_per_page] for i in range(0,len(argroup),num_ars_per_page)];">
 
-<!--
-    Page Header
-    A div element with the class "page-header" will be placed on the
-    top of the report, within the top margin area. This element
-    will be displayed on each page.
+<div class="ar_publish_body">
+  <tal:page_iter repeat="ars arspage">
+  <tal:page tal:define="
+      firstar         python:ars[0];
+      analysisrequest python:view.getAnalysisRequest(firstar);
+      client          analysisrequest/client;
+      contact         analysisrequest/contact;
+      laboratory      analysisrequest/laboratory;
+      portal          analysisrequest/portal;
+      showqcanalyses  python:view.isQCAnalysesVisible();
+      remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
 
-    Page numbering
-    For the number of page, use the "page-current-num" class.
-    For the total count, use the "page-total-count" class.
--->
-<div id="section-header" class='page-header'>
+  <!--
+      Page Header
+      A div element with the class "page-header" will be placed on the
+      top of the report, within the top margin area. This element
+      will be displayed on each page.
+
+      Page numbering
+      For the number of page, use the "page-current-num" class.
+      For the total count, use the "page-total-count" class.
+  -->
+  <div id="section-header" class="page-header">
     <div id='lab-logo'>
-        <a tal:attributes="href laboratory/url">
-            <img tal:attributes="src laboratory/logo"/>
-        </a>
+      <a tal:attributes="href laboratory/url">
+          <img tal:attributes="src laboratory/logo"/>
+      </a>
     </div>
-</div>
+  </div>
 
-<tal:ar tal:repeat="ar angroup">
-  <div tal:content="ar/id"></div>
-</tal:ar>
+  <!-- Address and Lab info -->
+  <div id="section-info">
+      <table width="100%">
+          <tr>
+              <td id="lab-info">
+                  <table>
+                      <tr><td id="lab-title" tal:content='laboratory/title'></td></tr>
+                      <tr><td id="lab-address" tal:content='structure laboratory/address'></td></tr>
 
-<!--
-    Page footer
-    A div element with the class "page-footer" will be placed in the
-    bottom of the report, within the bottom margin area. This element
-    will be displayed on each page.
-
-    Page numbering
-    For the number of page, use the "page-current-num" class.
-    For the total count, use the "page-total-count" class.
--->
-<div class='page-footer'>
-    <table>
+                      <tr tal:condition="laboratory/url">
+                          <td id="lab-URL">
+                              <a tal:attributes="href laboratory/url"
+                                 tal:content="laboratory/url"></a>
+                          </td>
+                      </tr>
+                  </table>
+              </td>
+          </tr>
+      </table>
+      <hr size="1"/>
+      <table width="100%" cellpadding="0" cellspacing="0">
         <tr>
-            <td class='footer-discreeter'>
-                <div class="page-number">Page <span class="page-current-num"></span> of <span class="page-total-count"></span></div>
-            </td>
+            <td i18n:translate="" class="label">Client</td>
+            <td id="client-name" tal:content="client/name"></td>
+            <td i18n:translate="" class="label">Address</td>
+            <td id="client-address" tal:content="structure client/address"></td>
         </tr>
+        <tr>
+            <td i18n:translate="" class="label">Client Contact</td>
+            <td id="client-contact" tal:content="python:contact.get('fullname','')"></td>
+            <td i18n:translate="" class="label">Received Date</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td i18n:translate="" class="label">Contact Email</td>
+            <td id="client-email">
+              <a tal:content="contact/email"
+                 tal:attributes="url python:'mailto:%s' % contact['email'];"></a>
+            </td>
+            <td i18n:translate="" class="label">Reporting Date</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td i18n:translate="" class="label">Contact Number</td>
+            <td></td>
+            <td i18n:translate="" class="label">Certificate Number</td>
+            <td></td>
+        </tr>
+      </table>
+      <hr size="1"/>
+  </div>
+
+  <!-- Analysis Requests table -->
+  <div id="ar-grid" tal:define="transposed python:view.getAnaysisBasedTransposedMatrix(ars);">
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <!-- Sample ID -->
+      <tr>
+        <th i18n:translate="" colspan="5">Sample ID</th>
+        <tal:ar repeat="ar ars">
+        <td tal:content="python:ar.getSample().id"
+            tal:attributes="id ar/id;uid ar/UID;"></td>
+        </tal:ar>
+      </tr>
+      <!-- Sample Type -->
+      <tr>
+        <th i18n:translate="" colspan="5">Sample Type</th>
+        <tal:ar repeat="ar ars">
+        <td tal:content="python:ar.getSample().getSampleType().title"></td>
+        </tal:ar>
+      </tr>
+      <!-- Sample Point -->
+      <tr>
+        <th i18n:translate="" colspan="5">Sample Point</th>
+        <tal:ar repeat="ar ars">
+        <td tal:content="python:ar.getSample().getSamplePointTitle()"></td>
+        </tal:ar>
+      </tr>
+
+      <!-- Tests/results -->
+      <tr>
+          <td class="blank-row" tal:attributes="colspan python:len(ars)+5;"></td>
+      </tr>
+      <tr>
+        <th i18n:translate="">Category</th>
+        <th i18n:translate="">Analysis</th>
+        <th>+/-</th>
+        <th i18n:translate="">Unit</th>
+        <th i18n:translate="">Method</th>
+        <th attributes="colspan python:len(ars)" i18n:translate="">Results</th>
+      </tr>
+      <tal:cats repeat="cat python:sorted(transposed.keys())">
+      <tr>
+        <td tal:content="cat" tal:attributes="rowspan python:len(transposed[cat].keys())+1"></td>
+      </tr>
+      <tr tal:repeat="service python:sorted(transposed[cat].keys())">
+        <td tal:content="service"></td>
+        <td></td>
+        <td tal:content="python:transposed[cat][service]['service'].getUnit()"></td>
+        <td tal:content="python:transposed[cat][service]['service'].getMethod().title if transposed[cat][service]['service'].getMethod() else ''"></td>
+        <tal:ar repeat="ar ars">
+        <td tal:content="python:transposed[cat][service]['ars'].get(ar.id,'')"></td>
+        </tal:ar>
+      </tr>
+      </tal:cats>
     </table>
+  </div>
+
+  <!--
+      Page footer
+      A div element with the class "page-footer" will be placed in the
+      bottom of the report, within the bottom margin area. This element
+      will be displayed on each page.
+
+      Page numbering
+      For the number of page, use the "page-current-num" class.
+      For the total count, use the "page-total-count" class.
+  -->
+  <div class='page-footer'>
+    <table>
+      <tr>
+        <td class='footer-discreeter'>
+          <div class="page-number">Page <span class="page-current-num"></span> of <span class="page-total-count"></span></div>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <!--
+      Manual break ("manual-page-break" css class)
+      We want to report to be splitted by the max number of ARs per page.
+
+      Restart page count ("restart-page-count" css class)
+      We want the number of pages to restart after the current page
+  -->
+  <div class='manual-page-break restart-page-count'></div>
+  </tal:page>
+  </tal:page_iter>
 </div>
-
-<!--
-    Manual break ("manual-page-break" css class)
-    We want to report to be splitted by departments.
-
-    Restart page count ("restart-page-count" css class)
-    We want the number of pages to restart after the current page
--->
-<div class='manual-page-break restart-page-count'></div>
-
 </tal:report>

--- a/bika/lims/vocabularies/__init__.py
+++ b/bika/lims/vocabularies/__init__.py
@@ -395,22 +395,76 @@ class ARPrioritiesVocabulary(BikaContentVocabulary):
                                        ['ARPriority', ])
 
 
-def getARReportTemplates():
-    p = os.path.join("browser", "analysisrequest", "templates", "reports")
-    templates_dir = resource_filename("bika.lims", p)
+def getTemplates(bikalims_path, restype):
+    """ Returns an array with the Templates available in the Bika LIMS path
+        specified plus the templates from the resources directory specified and
+        available on each additional product (restype).
+
+        Each array item is a dictionary with the following structure:
+            {'id': <template_id>,
+             'title': <template_title>}
+
+        If the template lives outside the bika.lims add-on, both the template_id
+        and template_title include a prefix that matches with the add-on
+        identifier. template_title is the same name as the id, but with
+        whitespaces and without extension.
+
+        As an example, for a template from the my.product add-on located in
+        <restype> resource dir, and with a filename "My_cool_report.pt", the
+        dictionary will look like:
+            {'id': 'my.product:My_cool_report.pt',
+             'title': 'my.product: My cool report'}
+    """
+    # Retrieve the templates from bika.lims add-on
+    templates_dir = resource_filename("bika.lims", bikalims_path)
     tempath = os.path.join(templates_dir, '*.pt')
     templates = [os.path.split(x)[-1] for x in glob.glob(tempath)]
-    out = [{'id': x, 'title': x} for x in templates]
-    for templates_resource in iterDirectoriesOfType('reports'):
+
+    # Retrieve the templates from other add-ons
+    for templates_resource in iterDirectoriesOfType(restype):
         prefix = templates_resource.__name__
+        if prefix == 'bika.lims':
+            continue
         dirlist = templates_resource.listDirectory()
-        templates = [tpl for tpl in dirlist if tpl.endswith('.pt')]
-        for template in templates:
-            out.append({
-                'id': '{0}:{1}'.format(prefix, template),
-                'title': '{0}:{1}'.format(prefix, template),
-            })
+        exts = ['{0}:{1}'.format(prefix, tpl) for tpl in dirlist if
+                tpl.endswith('.pt')]
+        templates.extend(exts)
+
+    out = []
+    templates.sort()
+    for template in templates:
+        title = template[:-3]
+        title = title.replace('_', ' ')
+        title = title.replace(':', ': ')
+        out.append({'id': template,
+                    'title': title})
+
     return out
+
+
+def getARReportTemplates():
+    """ Returns an array with the AR Templates available in Bika LIMS  plus the
+        templates from the 'reports' resources directory type from each
+        additional product.
+
+        Each array item is a dictionary with the following structure:
+            {'id': <template_id>,
+             'title': <template_title>}
+
+        If the template lives outside the bika.lims add-on, both the template_id
+        and template_title include a prefix that matches with the add-on
+        identifier. template_title is the same name as the id, but with
+        whitespaces and without extension.
+
+        As an example, for a template from the my.product add-on located in
+        templates/reports dir, and with a filename "My_cool_report.pt", the
+        dictionary will look like:
+            {'id': 'my.product:My_cool_report.pt',
+             'title': 'my.product: My cool report'}
+    """
+    resdirname = 'reports'
+    p = os.path.join("browser", "analysisrequest", "templates", resdirname)
+    return getTemplates(p, resdirname)
 
 
 class ARReportTemplatesVocabulary(object):
@@ -444,31 +498,9 @@ def getStickerTemplates():
              'title': 'my.product: EAN128 default small'}
     """
     # Retrieve the templates from bika.lims add-on
-    p = os.path.join("browser", "templates", "stickers")
-    templates_dir = resource_filename("bika.lims", p)
-    tempath = os.path.join(templates_dir, '*.pt')
-    templates = [os.path.split(x)[-1] for x in glob.glob(tempath)]
-
-    # Retrieve the templates from other add-ons
-    for templates_resource in iterDirectoriesOfType('stickers'):
-        prefix = templates_resource.__name__
-        if prefix == 'bika.lims':
-            continue
-        dirlist = templates_resource.listDirectory()
-        exts = ['{0}:{1}'.format(prefix, tpl) for tpl in dirlist if
-                tpl.endswith('.pt')]
-        templates.extend(exts)
-
-    out = []
-    templates.sort()
-    for template in templates:
-        title = template[:-3]
-        title = title.replace('_', ' ')
-        title = title.replace(':', ': ')
-        out.append({'id': template,
-                    'title': title})
-
-    return out
+    resdirname = 'stickers'
+    p = os.path.join("browser", "templates", resdirname)
+    return getTemplates(p, resdirname)
 
 
 class StickerTemplatesVocabulary(object):

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.10 (unreleased)
 -------------------
+LIMS-1832: New Results Template, COA. Multiple ARs in columns
 LIMS-1933: Regression: Selecting secondary AR in client batches, fails.
 
 3.1.9 (2015-10-8)


### PR DESCRIPTION
**Ticket**: https://jira.bikalabs.com/browse/LIMS-1832

Result templates with the prefix Multi will be treated as multi-ar reports. (i.e. `multi_my_gorgeous_report.pt`). Custom templates for multi-ar reports can be created following the same procedure as the single-ar reports:
https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates

The ARs are grouped automatically by client and only one report (with the ARs from that client included) per client is generated. The number of ARs to render per page is responsability of the template itself, see line 18 from the Bika's default multi-ar template:

https://github.com/xispa/Bika-LIMS/blob/feature/LIMS-1832-multiar-reports/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt#L18

![multi-ar-report](https://cloud.githubusercontent.com/assets/832627/10546751/2ada96ba-7430-11e5-8169-14121b0bbdeb.png)

