### PR TITLE
LIMS-2115: Error rises when saving a Calculation

### DIFF
--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -12,23 +12,24 @@ def ObjectModifiedEventHandler(obj, event):
         pr = getToolByName(obj, 'portal_repository')
         uc = getToolByName(obj, 'uid_catalog')
         obj = uc(UID=obj.UID())[0].getObject()
+        version_id = obj.version_id if hasattr(obj, 'version_id') else 0
 
         backrefs = obj.getBackReferences('AnalysisServiceCalculation')
         for i, target in enumerate(backrefs):
             target = uc(UID=target.UID())[0].getObject()
             pr.save(obj=target, comment="Calculation updated to version %s" %
-                (obj.version_id + 1,))
+                (version_id + 1,))
             reference_versions = getattr(target, 'reference_versions', {})
-            reference_versions[obj.UID()] = obj.version_id + 1
+            reference_versions[obj.UID()] = version_id + 1
             target.reference_versions = reference_versions
 
         backrefs = obj.getBackReferences('MethodCalculation')
         for i, target in enumerate(backrefs):
             target = uc(UID=target.UID())[0].getObject()
             pr.save(obj=target, comment="Calculation updated to version %s" %
-                (obj.version_id + 1,))
+                (version_id + 1,))
             reference_versions = getattr(target, 'reference_versions', {})
-            reference_versions[obj.UID()] = obj.version_id + 1
+            reference_versions[obj.UID()] = version_id + 1
             target.reference_versions = reference_versions
 
     elif obj.portal_type == 'Client':
@@ -46,5 +47,3 @@ def ObjectModifiedEventHandler(obj, event):
     elif obj.portal_type == 'AnalysisCategory':
         for analysis in obj.getBackReferences('AnalysisServiceAnalysisCategory'):
             analysis.reindexObject(idxs=["getCategoryTitle", "getCategoryUID", ])
-
-

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -6,6 +6,7 @@ LIMS-2075: Ensure hiding of pricing information when disabled in site-setup
 LIMS-2081: AR Batch Import WorkflowException after edit
 LIMS-2106: Attribute error when creating AR inside batch with no client.
 LIMS-2080: Correctly interpret default (empty) values in ARImport CSV file
+LIMS-2115: Error rises when saving a Calculation
 
 3.1.9 (2015-10-8)
 ------------------


### PR DESCRIPTION
When trying to edit and save a calculation imported directly from the setupdata spreadsheet.
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 105, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 1, in content_edit
   - <FSControllerPythonScript at /Plone/content_edit used for /Plone/bika_setup/bika_calculations/calculation-1>
   - Line 1
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 12, in content_edit_impl
   - <FSPythonScript at /Plone/content_edit_impl used for /Plone/bika_setup/bika_calculations/calculation-1>
   - Line 12
  Module Products.Archetypes.BaseObject, line 667, in processForm
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.subscribers.objectmodified, line 20, in ObjectModifiedEventHandler
AttributeError: version_id
```