### PR TITLE
LIMS-2116: JSONAPI throws an UnicodeDecodeError

### DIFF
--- a/bika/lims/jsonapi/__init__.py
+++ b/bika/lims/jsonapi/__init__.py
@@ -1,6 +1,7 @@
 from Products.Archetypes.config import TOOL_NAME
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
+from bika.lims.utils import safe_unicode
 import json
 import Missing
 import sys, traceback
@@ -73,18 +74,21 @@ def load_field_values(instance, include_fields):
             print traceback.format_exc()
 
         if val:
-            if field.type == "blob":
+            if field.type == "blob" or field.type == 'file':
                 continue
             # I put the UID of all references here in *_uid.
             if field.type == 'reference':
                 if type(val) in (list, tuple):
                     ret[fieldname + "_uid"] = [v.UID() for v in val]
-                    val = [v.Title() for v in val]
+                    val = [safe_unicode(v.Title()) for v in val]
                 else:
                     ret[fieldname + "_uid"] = val.UID()
-                    val = val.Title()
-            if field.type == 'boolean':
+                    val = safe_unicode(val.Title())
+            elif field.type == 'boolean':
                 val = True if val else False
+            elif field.type == 'text':
+                val = safe_unicode(val)
+
         try:
             json.dumps(val)
         except:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -6,6 +6,7 @@ LIMS-2075: Ensure hiding of pricing information when disabled in site-setup
 LIMS-2081: AR Batch Import WorkflowException after edit
 LIMS-2106: Attribute error when creating AR inside batch with no client.
 LIMS-2080: Correctly interpret default (empty) values in ARImport CSV file
+LIMS-2116: JSONAPI throws an UnicodeDecodeError
 
 3.1.9 (2015-10-8)
 ------------------


### PR DESCRIPTION
```
/Plone/@@API/read
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.jsonapi.core.browser.api, line 64, in __call__
  Module plone.jsonapi.core.browser.decorators, line 48, in decorator
  Module simplejson, line 321, in dumps
  Module simplejson.encoder, line 237, in encode
  Module simplejson.encoder, line 311, in iterencode
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe2 in position 10: invalid continuation byte
```