### PR TITLE
Return specs of each analysis to report

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -562,6 +562,10 @@ class AnalysisRequestPublishView(BrowserView):
         andict['formatted_specs'] = formatDecimalMark(fs, decimalmark)
         andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
 
+        # Return specs of current analysis
+        analysis_specs = analysis.getSpecification().getResultsRangeDict().get(analysis.id)
+        andict['specs_dict'] = analysis_specs
+
         # Out of range?
         if specs:
             adapters = getAdapters((analysis, ), IResultOutOfRange)

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -563,8 +563,7 @@ class AnalysisRequestPublishView(BrowserView):
         andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
 
         # Return specs of current analysis
-        analysis_specs = analysis.getSpecification().getResultsRangeDict().get(analysis.id)
-        andict['specs_dict'] = analysis_specs
+        andict['specs_dict'] = analysis.getSpecification().getResultsRangeDict().get(analysis.id)
 
         # Out of range?
         if specs:


### PR DESCRIPTION
Added the specs_dict to return specs informations of each analysis to report

Usage:
Added the var specs_dict returning specs informations of each analysis to report


Usage:
\<span tal:condition="analysis/specs_dict/rangecomment | nothing">
\<span tal:content="structure analysis/specs_dict/rangecomment | nothing">\</span>
\</span>

