### PR TITLE
WINE-71 Instrument. BBK WS export to FIA fails

### DIFF
--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -115,18 +115,18 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
         ),
     ),
 
-    #TODO: To be removed?
     StringField('DataInterface',
-        vocabulary = "getDataInterfacesList",
-        widget = ReferenceWidget(
+        vocabulary = "getExportDataInterfacesList",
+        widget = SelectionWidget(
             checkbox_bound = 0,
             label=_("Data Interface"),
-            description=_("Select an Import/Export interface for this instrument."),
-            visible = False,
+            description=_("Select an Export interface for this instrument."),
+            format='select',
+            default='',
+            visible = True,
         ),
     ),
 
-    #TODO: To be removed?
     RecordsField('DataInterfaceOptions',
         type = 'interfaceoptions',
         subfields = ('Key','Value'),
@@ -245,14 +245,17 @@ schema.moveField('InstrumentTypeName', before='ManufacturerName')
 schema['description'].widget.visible = True
 schema['description'].schemata = 'default'
 
-def getDataInterfaces(context):
+def getDataInterfaces(context, export_only=False):
     """ Return the current list of data interfaces
     """
     from bika.lims.exportimport import instruments
     exims = []
     for exim_id in instruments.__all__:
         exim = instruments.getExim(exim_id)
-        exims.append((exim_id, exim.title))
+        if export_only and not hasattr(exim, 'Export'):
+            pass
+        else:
+            exims.append((exim_id, exim.title))
     exims.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
     exims.insert(0, ('', t(_('None'))))
     return DisplayList(exims)
@@ -282,8 +285,8 @@ class Instrument(ATFolder):
     def Title(self):
         return to_utf8(safe_unicode(self.title))
 
-    def getDataInterfacesList(self):
-        return getDataInterfaces(self)
+    def getExportDataInterfacesList(self):
+        return getDataInterfaces(self, export_only=True)
 
     def getScheduleTaskTypesList(self):
         return getMaintenanceTypes(self)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.10 (unreleased)
 -------------------
 - Dashboard: replace multi-bar charts by stacked-bar charts
+WINE-71: Instrument. BBK WS export to FIA fails
 LIMS-1906: Spaces should be stripped out of the keywords coming from the Instrument
 LIMS-2117: Analysis Categories don't expand on Analysis Specification creation
 LIMS-1933: Regression: Selecting secondary AR in client batches, fails.


### PR DESCRIPTION
[JIRA](https://jira.bikalabs.com/browse/WINE-71)

I don't know why Xispa set "DataInterfaceOptions" and" DataInterface" as not visible [here](https://github.com/bikalabs/Bika-LIMS/commit/58ef0fa48f0c1755d7640961513754d20319fa91#diff-2fb6d23392fdd7c495dcccf7aec97f3fR100).

To use the Export system the user has to select the Export instrument interface he/she wants to use from the instrument edition page.